### PR TITLE
make buildflags more complete and overridable

### DIFF
--- a/auxprogs/aln2wig/Makefile
+++ b/auxprogs/aln2wig/Makefile
@@ -1,10 +1,12 @@
 CFLAGS := -Wall -Wno-sign-compare -ansi -pedantic -O2 -ggdb ${CFLAGS}
+CC?=gcc
 
 aln2wig : aln2wig.o
-	gcc $(CFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -o aln2wig aln2wig.o;
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o aln2wig aln2wig.o
+	mkdir -p ../../bin
 	cp aln2wig ../../bin
 aln2wig.o : aln2wig.c
-	gcc $(CPPFLAGS) $(CXXFLAGS) $(CFLAGS) $(LDFLAGS) -c aln2wig.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c aln2wig.c
 
 all : aln2wig
 

--- a/auxprogs/bam2hints/Makefile
+++ b/auxprogs/bam2hints/Makefile
@@ -8,26 +8,26 @@
 #	Last modified:  09-October-2015 by Katharina J. Hoff
 
 # Variable definition
-INCLUDES = /usr/include/bamtools
+INCLUDES = -I/usr/include/bamtools
 LIBS = -lbamtools -lz
 SOURCES = bam2hints.cc 
 OBJECTS = $(SOURCES:.cc=.o)
 CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
 
-LINK.cc = g++
+LINK.cc ?= g++
 
 # Recipe(s)
 # $@: full target name of current target. 
 # $<: .c file of target. 
 bam2hints : $(OBJECTS) 
-	$(LINK.cc) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJECTS) $(LIBS)
+	$(LINK.cc) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(OBJECTS) $(LIBS)
 	mkdir -p ../../bin
 	cp bam2hints ../../bin
 
 all:$(OBJECTS) # Compiles each foo.cc into foo.o
 
 bam2hints.o : $(SOURCES)
-	$(LINK.cc) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -c $< -o $@ -I$(INCLUDES) 
+	$(LINK.cc) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@ $(INCLUDES) 
 
 clean:
 	rm -f bam2hints.o bam2hints ../../bin/bam2hints

--- a/auxprogs/bam2wig/Makefile
+++ b/auxprogs/bam2wig/Makefile
@@ -21,17 +21,17 @@ BCFTOOLS=$(TOOLDIR)/bcftools
 INCLUDES=-I$(SAMTOOLS) -I. -I$(HTSLIB) -I$(BCFTOOLS)
 VPATH=$(SAMTOOLS)
 LIBS=$(SAMTOOLS)/libbam.a $(HTSLIB)/libhts.a -lcurses -lm -lz -lpthread -lcurl -lssl -lcrypto
-CFLAGS=-Wall -O2 $(INCLUDES)
-CC=gcc
+CFLAGS:=-Wall -O2 $(INCLUDES) $(CFLAGS)
+CC?=gcc
 
 $(PROGRAM) : bam2wig.o
-	$(CC) $(CFLAGS) $^ -o $@ $(LIBS) -lbz2 -llzma
+	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS) -lbz2 -llzma
 	mkdir -p ../../bin
 	cp bam2wig ../../bin/bam2wig
 
 bam2wig.o : bam2wig.c
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
-	rm -f $(OBJECTS) bam2wig.o
+	rm -f $(OBJECTS) bam2wig.o bam2wig
 	rm -f ../../bin/bam2wig

--- a/auxprogs/checkTargetSortedness/Makefile
+++ b/auxprogs/checkTargetSortedness/Makefile
@@ -18,7 +18,7 @@ SAMTOOLS = /usr/include/samtools
 INCLUDES = -I$(SAMTOOLS) -I.
 # replace -lbam with the following in case you have your own samtools library: $(SAMTOOLS)/libbam.a
 LIBS=-lbam -lcurses -lm -lz -lpthread
-CC=gcc
+CC?=gcc
 
 all:$(PROGRAM) $(OBJECTS)
 
@@ -26,7 +26,7 @@ $(PROGRAM):$(OBJECTS)
 	$(CC) $(CFLAGS)	$(CPPFLAGS) $(LDFLAGS) $^ -o $@ $(LIBS) 
 
 $(OBJECTS):%.o:%.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -c $^ -o $@ $(INCLUDES)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@ $(INCLUDES)
 
 clean:
 	rm -f *.o checkTargetSortedness

--- a/auxprogs/compileSpliceCands/Makefile
+++ b/auxprogs/compileSpliceCands/Makefile
@@ -1,8 +1,11 @@
+CC?=gcc
+
 compileSpliceCands : compileSpliceCands.o list.h list.o
-	gcc $(LDFLAGS) -o compileSpliceCands compileSpliceCands.o list.o;
+	$(CC) $(CFLAGS)	$(CPPFLAGS) $(LDFLAGS) -o compileSpliceCands compileSpliceCands.o list.o
 #	cp compileSpliceCands ../../bin
+
 compileSpliceCands.o : compileSpliceCands.c 
-	gcc -Wall -pedantic -ansi $(CPPFLAGS) -c compileSpliceCands.c 
+	$(CC) -Wall -pedantic -ansi $(CFLAGS) $(CPPFLAGS) -c compileSpliceCands.c
 
 all : compileSpliceCands
 

--- a/auxprogs/filterBam/src/Makefile
+++ b/auxprogs/filterBam/src/Makefile
@@ -11,12 +11,14 @@ OBJECTS = $(SOURCES:.cc=.o)
 BAMTOOLS = /usr/include/bamtools
 INCLUDES = -I$(BAMTOOLS) -Iheaders -I./bamtools
 LIBS = -lbamtools -lz
-CFLAGS = -std=c++0x
+CXXFLAGS := -std=c++0x ${CXXFLAGS}
 VPATH = functions
+LINK.cc ?= g++
 
 all : $(PROGRAM) $(OBJECTS) CHECKBAM BIN
 
 BIN : $(PROGRAM) CHECKBAM
+	mkdir -p ../../../bin
 	mv filterBam ../../../bin/filterBam
 
 CHECKBAM:
@@ -28,12 +30,13 @@ CHECKBAM:
 	fi
 
 $(PROGRAM) : $(OBJECTS)
-	$(LINK.cc) $(CFLAGS) $(LDFLAGS) $^ -o $@ $(LIBS) 
+	$(LINK.cc) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 $(OBJECTS) : %.o:%.cc
-	$(LINK.cc) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@ $(INCLUDES)
+	$(LINK.cc) $(CXXFLAGS) $(CPPFLAGS) -c $^ -o $@ $(INCLUDES)
 
 
 clean:
 	rm -f *~ $(OBJECTS)
+	rm -f filterBam
 	rm -f ../../../bin/filterBam

--- a/auxprogs/homGeneMapping/src/Makefile
+++ b/auxprogs/homGeneMapping/src/Makefile
@@ -12,26 +12,26 @@ ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE)) # if COMPGENEPRED is n
 	SQLITE ?= true
 endif
 
-CC      = g++
+CXX   ?= g++
 
 # Notes: - "-Wno-sign-compare" eliminates a high number of warnings (see footnote below). Please adopt
 #          a strict signed-only usage strategy to avoid mistakes since we are not warned about this.
 #        - The order of object files in $(OBJS) IS IMPORTANT (see lldouble.hh)
-CFLAGS := -Wall -Wno-sign-compare -ansi -pedantic -std=c++0x -pthread -O2 ${CFLAGS} # -DDEBUG -g -ggdb -pg
+CXXFLAGS := -Wall -Wno-sign-compare -ansi -pedantic -std=c++0x -pthread -O2 ${CXXFLAGS}
 
 INCLS	= -I../include
 LIBS	=
 OBJS	= gene.o genome.o
 
 ifeq (,$(findstring $(BOOST),0 false False FALSE)) # if BOOST is not defined or not contains 0, false, False or FALSE
-	CFLAGS += -DBOOST
+	CPPFLAGS += -DBOOST
 	INCLS +=  # add the boost include path here, if boost ist not installed system-wide
 endif
 
 ifneq (,$(findstring $(SQLITE),1 true True TRUE)) # if SQLITE is defined and contains 1, true, True or TRUE
 	LIBS    += -lsqlite3 # add the sqlite library path here, if sqlite is not install system-wide
 	OBJS    += sqliteDB.o
-	CFLAGS  += -DM_SQLITE
+	CPPFLAGS  += -DM_SQLITE
 endif
 
 all: homGeneMapping
@@ -40,10 +40,10 @@ all: homGeneMapping
 .SUFFIXES: .cc .o .so
 
 .cc.o:
-	$(CC) -c $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $< $(INCLS)
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) -o $@ $< $(INCLS)
 
 homGeneMapping: main.cc $(OBJS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^ $(INCLS)  $(LIBS)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^ $(INCLS) $(LIBS)
 	mkdir -p ../../../bin/
 	cp homGeneMapping ../../../bin/homGeneMapping
 

--- a/auxprogs/joingenes/Makefile
+++ b/auxprogs/joingenes/Makefile
@@ -1,20 +1,21 @@
-CC=g++
-CFLAGS=-Wall -std=gnu++0x
+CXX?=g++
+CXXFLAGS+=-Wall -std=gnu++0x
 
 all: joingenes
 
 joingenes: joingenes.o jg_transcript.o jg_ios.o jg_transcript.h jg_ios.h
-	$(CC) $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) joingenes.o jg_transcript.o jg_ios.o -o joingenes
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) joingenes.o jg_transcript.o jg_ios.o -o joingenes
+	mkdir -p ../../bin/
 	cp joingenes ../../bin/
 
 joingenes.o: joingenes.cpp jg_transcript.h jg_ios.h
-	$(CC) -c $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) ${LDFLAGS} joingenes.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) joingenes.cpp
 
 jg_transcript.o: jg_transcript.cpp jg_transcript.h
-	$(CC) -c $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) ${LDFLAGS} jg_transcript.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) jg_transcript.cpp
 
 jg_ios.o: jg_ios.cpp jg_ios.h jg_transcript.h
-	$(CC) -c $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) ${LDFLAGS} jg_ios.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) jg_ios.cpp
 
 clean:
-	rm -rf *o joingenes; rm -rf ../../bin/joingenes
+	rm -rf *.o joingenes; rm -rf ../../bin/joingenes

--- a/auxprogs/utrrnaseq/Debug/makefile
+++ b/auxprogs/utrrnaseq/Debug/makefile
@@ -35,6 +35,8 @@ endif
 
 -include ../makefile.defs
 
+CXX?=g++
+
 # Add inputs and outputs from these tool invocations to the build variables 
 
 # All Target
@@ -44,7 +46,7 @@ all: utrrnaseq
 utrrnaseq: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	g++  -o "utrrnaseq" $(OBJS) $(USER_OBJS) $(LIBS)
+	$(CXX)  -o "utrrnaseq" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 # Makefile for Augustus
 #
 include ../common.mk
-CXX	= g++
+CXX?=g++
 
 # Notes: - "-Wno-sign-compare" eliminates a high number of warnings (see footnote below). Please adopt
 #          a strict signed-only usage strategy to avoid mistakes since we are not warned about this.
@@ -10,7 +10,7 @@ CXX	= g++
 CXXFLAGS := -Wall -Wno-sign-compare -pedantic -g -ggdb -O3 ${CXXFLAGS} #-DDEBUG -g -ggdb -pg -DDEBUG_STATES
 
 ifeq (,$(findstring $(ZIPINPUT),0 false False FALSE))  # if ZIPINPUT is not defined or is something else than 0, false, False or FALSE
-	CXXFLAGS += -DZIPINPUT
+	CPPFLAGS += -DZIPINPUT
 	LIBS    = -lboost_iostreams
 endif
 
@@ -23,7 +23,8 @@ OBJS	= genbank.o properties.o pp_profile.o pp_hitseq.o pp_scoring.o statemodel.o
 ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE))  # if COMPGENEPRED is not defined or is something else than 0, false, False or FALSE
 	SQLITE   ?= true
 	MYSQL    ?= true
-	CXXFLAGS += -std=c++11 -DCOMPGENEPRED
+	CXXFLAGS += -std=c++11
+	CPPFLAGS += -DCOMPGENEPRED
 	OBJS += parser/parse.o scanner/lex.o genomicMSA.o geneMSA.o contTimeMC.o compgenepred.o phylotree.o orthograph.o orthoexon.o alignment.o speciesgraph.o codonMSA.o train_logReg_param.o
 	LIBS += -lgsl -lgslcblas # for matrix exponentiation that is required in comparative gene finding
 	LIBS += -llpsolve55 -lcolamd -ldl # for mixed integer linear programming (alignment.cc)
@@ -41,7 +42,7 @@ ifneq (,$(findstring $(MYSQL),1 true True TRUE)) # if MYSQL is defined and conta
 	RUNTIME_LIBPATH =
 	INCLS    += -I/usr/include/mysql -I/usr/include/mysql++ # the path to mysql++ may have to be adjusted
 	LIBS     += -lmysqlclient -lmysqlpp ${RUNTIME_LIBPATH} # -L/usr/local/lib/libmysqlpp.so.3.1.0
-	CXXFLAGS += -DM_MYSQL
+	CPPFLAGS += -DM_MYSQL
 	PROGR    += load2db getSeq
 endif
 
@@ -49,7 +50,7 @@ ifneq (,$(findstring $(SQLITE),1 true True TRUE)) # if SQLITE is defined and con
 	# SQLite support
 	LIBS      += -lsqlite3
 	OBJS      += sqliteDB.o
-	CXXFLAGS  += -DM_SQLITE
+	CPPFLAGS  += -DM_SQLITE
 	PROGR     += load2sqlitedb getSeq
 endif
 
@@ -64,7 +65,7 @@ all: $(OBJS) $(TOBJS) $(DUMOBJS) $(PROGR) info
 .PHONY: googletest
 
 .cc.o:
-	$(CXX) -c $(CXXFLAGS) -o $@ $< $(INCLS)
+	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(INCLS)
 
 augustus: augustus.cc $(OBJS) $(DUMOBJS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(INCLS) $(LIBS)
@@ -115,10 +116,10 @@ espoca: espoca.cc $(OBJS) $(DUMOBJS)
 	cp espoca ../bin/
 
 info:
-	echo "$(CXXFLAGS)" > $(INFO)
+	echo "$(CXXFLAGS) $(CPPFLAGS)" > $(INFO)
 
 clean:
-	rm -f ../bin/* $(PROGR) $(OBJS) $(DUMOBJS) $(TOBJS) consensus.o exon_seg.o pp_fastBlockSearcher.o  $(INFO)
+	rm -f ../bin/* $(PROGR) $(OBJS) $(DUMOBJS) $(TOBJS) consensus.o exon_seg.o pp_fastBlockSearcher.o $(INFO)
 	cd googletest && ${MAKE} clean
 	cd unittests && ${MAKE} clean
 

--- a/src/unittests/Makefile
+++ b/src/unittests/Makefile
@@ -1,6 +1,6 @@
 include ../../common.mk
 AINC = ../../include
-CXX = g++
+CXX ?= g++
 CXXFLAGS := -std=c++11 -Wall -pedantic -pthread ${CXXFLAGS}
 LDFLAGS = -L../googletest -lgtest -lgtest_main
 INCLS	+= -I$(AINC) -isystem ../googletest/include/
@@ -11,10 +11,10 @@ unittests: lldouble_unittest.o fasta_unittest.o
 
 # Here follows each individual Unit Test
 lldouble_unittest.o: lldouble_unittest.cc $(AINC)/lldouble.hh
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(INCLS) -c lldouble_unittest.cc
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLS) -c lldouble_unittest.cc
 
 fasta_unittest.o: fasta_unittest.cc $(AINC)/fasta.hh
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(INCLS) -c fasta_unittest.cc
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLS) -c fasta_unittest.cc
 
 # execute all tests: run test binary
 test: unittests


### PR DESCRIPTION
This PR adds previously missing buildflags to compiler/linker calls that allow external build environments to add in custom flags.
This makes life easier for packagers. For example, Debian builds would override `LDFLAGS` and `CPPFLAGS`/`CXXFLAGS` to insert additional options for hardening and reproducibility.
Also, allow to override `CC`  by setting a custom value.