### PR TITLE
Msa tools

### DIFF
--- a/include/alignment.hh
+++ b/include/alignment.hh
@@ -77,6 +77,9 @@ public:
     // convert from alignment to chromosomal position (inverse function of getAliPos())
     int getChrPos(int aliPos, vector<fragment>::const_iterator from);
     int getChrPos(int aliPos) { return getChrPos(aliPos, frags.begin()); }
+	
+	// retrieve a pattern describing blocks of (unaligned, gaps, aligned nts) to rebuild the alignment 
+	int getSeqInfo(int chrStart, int chrEnd, vector<int>& pattern);
     
     // data members
     string seqID; // e.g. chr21

--- a/include/compgenepred.hh
+++ b/include/compgenepred.hh
@@ -13,6 +13,17 @@
 #include "randseqaccess.hh"
 #include "phylotree.hh"
 
+
+/*
+*   added by Giovanna Migliorelli 10.10.2019 
+*   headers for functions in charge of printing MSA associated with some OE
+*/
+void ec2Chr(int ecStart, int ecEnd, int offset, int chrLen, Strand strand, int& chrStart, int& chrEnd, bool referToPlus);
+void printMSA_printEC_helper(ostream& os, GeneMSA* geneRange, int sp, vector<string>& speciesNames, RandSeqAccess* rsa, int chrStart, int chrEnd, AnnoSequence* as, bool expandUnaligned);
+void printMSA_printEC(ostream& os, vector<string>& speciesNames, RandSeqAccess* rsa, GeneMSA* geneRange, int sp, ExonCandidate* ec, bool downcase, bool expandUnaligned);
+void printMSA(ostream& os, vector<string>& speciesNames, RandSeqAccess* rsa, GeneMSA* geneRange, OrthoExon& oe, bool extraInfo, bool expandUnaligned);
+
+
 /**
  * @brief comparative gene prediction on multiple species
  * 

--- a/include/compgenepred.hh
+++ b/include/compgenepred.hh
@@ -13,17 +13,6 @@
 #include "randseqaccess.hh"
 #include "phylotree.hh"
 
-
-/*
-*   added by Giovanna Migliorelli 10.10.2019 
-*   headers for functions in charge of printing MSA associated with some OE
-*/
-void ec2Chr(int ecStart, int ecEnd, int offset, int chrLen, Strand strand, int& chrStart, int& chrEnd, bool referToPlus);
-void printMSA_printEC_helper(ostream& os, GeneMSA* geneRange, int sp, vector<string>& speciesNames, RandSeqAccess* rsa, int chrStart, int chrEnd, AnnoSequence* as, bool expandUnaligned);
-void printMSA_printEC(ostream& os, vector<string>& speciesNames, RandSeqAccess* rsa, GeneMSA* geneRange, int sp, ExonCandidate* ec, bool downcase, bool expandUnaligned);
-void printMSA(ostream& os, vector<string>& speciesNames, RandSeqAccess* rsa, GeneMSA* geneRange, OrthoExon& oe, bool extraInfo, bool expandUnaligned);
-
-
 /**
  * @brief comparative gene prediction on multiple species
  * 

--- a/src/alignment.cc
+++ b/src/alignment.cc
@@ -885,8 +885,8 @@ int AlignmentRow::getSeqInfo(int chrStart, int chrEnd, vector<int>& pattern){
 	while(to<frags.size() && frags[to].chrPos+frags[to].len-1 < chrEnd)
 		++to;
 
-	if(to==frags.size() || (to == frags.size()-1 && chrEnd > frags.back().chrPos+frags.back().len - 1))// should never be the case
-		return -2;
+	if(to==frags.size() || (to == frags.size()-1 && chrEnd > frags.back().chrPos+frags.back().len - 1))
+		return -2;	// should never be the case
 
 	start = chrStart;
 	pt = from;
@@ -895,23 +895,20 @@ int AlignmentRow::getSeqInfo(int chrStart, int chrEnd, vector<int>& pattern){
 		if(pt == from){			
 			if(start<frags[pt].chrPos){
 				pattern.push_back(frags[pt].chrPos - start); 	// unaligned
-				pattern.push_back(frags[pt].len);		// aligned nts
+				pattern.push_back(frags[pt].len);				// aligned nts
 			}
 			else{ 
-				pattern.push_back(0); 						// unaligned
+				pattern.push_back(0); 											// unaligned
 				pattern.push_back(frags[pt].chrPos + frags[pt].len - start); 	// aligned nts
-			
-
 			}
 
 			pattern.push_back(0); // gaps
 		}
 		else{
 			pattern.push_back(frags[pt].chrPos - (frags[pt-1].chrPos + frags[pt-1].len -1) - 1); 	// unaligned
-			pattern.push_back(frags[pt].len);							// aligned nts
+			pattern.push_back(frags[pt].len);														// aligned nts
 			pattern.push_back(frags[pt].aliPos - (frags[pt-1].aliPos + frags[pt-1].len - 1) - 1); 	// gaps
 		}
-		 
 		
 		start = frags[pt].chrPos + frags[pt].len;
 		++pt;
@@ -920,20 +917,16 @@ int AlignmentRow::getSeqInfo(int chrStart, int chrEnd, vector<int>& pattern){
 	// pt == to	
 	if(chrEnd<frags[to].chrPos){
 		pattern.push_back(chrEnd-start+1); 	// unaligned
-		pattern.push_back(0); 			// aligned nts
+		pattern.push_back(0); 				// aligned nts
 	}
 	else{
 		if (start < frags[pt].chrPos){
 			pattern.push_back(frags[pt].chrPos - start); 		// unaligned
 			pattern.push_back(chrEnd - frags[pt].chrPos + 1);	// aligned nts
-			
-			
-
 		}
 		else{
-			pattern.push_back(0);			// unaligned
+			pattern.push_back(0);					// unaligned
 			pattern.push_back(chrEnd - start + 1);	// aligned nts	
-
 		}
 	}
 	
@@ -943,7 +936,6 @@ int AlignmentRow::getSeqInfo(int chrStart, int chrEnd, vector<int>& pattern){
 	}
 	else{
 		pattern.push_back(frags[pt].aliPos - (frags[pt-1].aliPos + frags[pt-1].len - 1) - 1); // gaps
-		
 	}
 	
 	return 0;

--- a/src/alignment.cc
+++ b/src/alignment.cc
@@ -866,5 +866,89 @@ void Alignment::pack(){
 }
 
 
+/*
+*   added by Giovanna Migliorelli 10.10.2019 
+*   The following function allows to retrieve a pattern from the alignment containing blocks of unaligned nts,gaps,aligned nts 
+*   todo : the function assumes the first position not to fall within gaps (relax this constraint to make the code robust)
+*   formatting the code according to Augustus style guidelines
+*/
+int AlignmentRow::getSeqInfo(int chrStart, int chrEnd, vector<int>& pattern){
+	int from = 0, to, pt, start;
+	while(from<frags.size() && frags[from].chrPos+frags[from].len-1 < chrStart){
+		++from;
+	}
+	
+	if(from == 0 && chrStart < frags[0].chrPos) // should never be the case
+		return -1;
+
+	to = from;
+	while(to<frags.size() && frags[to].chrPos+frags[to].len-1 < chrEnd)
+		++to;
+
+	if(to==frags.size() || (to == frags.size()-1 && chrEnd > frags.back().chrPos+frags.back().len - 1))// should never be the case
+		return -2;
+
+	start = chrStart;
+	pt = from;
+
+	while(pt<to){
+		if(pt == from){			
+			if(start<frags[pt].chrPos){
+				pattern.push_back(frags[pt].chrPos - start); 	// unaligned
+				pattern.push_back(frags[pt].len);		// aligned nts
+			}
+			else{ 
+				pattern.push_back(0); 						// unaligned
+				pattern.push_back(frags[pt].chrPos + frags[pt].len - start); 	// aligned nts
+			
+
+			}
+
+			pattern.push_back(0); // gaps
+		}
+		else{
+			pattern.push_back(frags[pt].chrPos - (frags[pt-1].chrPos + frags[pt-1].len -1) - 1); 	// unaligned
+			pattern.push_back(frags[pt].len);							// aligned nts
+			pattern.push_back(frags[pt].aliPos - (frags[pt-1].aliPos + frags[pt-1].len - 1) - 1); 	// gaps
+		}
+		 
+		
+		start = frags[pt].chrPos + frags[pt].len;
+		++pt;
+	}
+	
+	// pt == to	
+	if(chrEnd<frags[to].chrPos){
+		pattern.push_back(chrEnd-start+1); 	// unaligned
+		pattern.push_back(0); 			// aligned nts
+	}
+	else{
+		if (start < frags[pt].chrPos){
+			pattern.push_back(frags[pt].chrPos - start); 		// unaligned
+			pattern.push_back(chrEnd - frags[pt].chrPos + 1);	// aligned nts
+			
+			
+
+		}
+		else{
+			pattern.push_back(0);			// unaligned
+			pattern.push_back(chrEnd - start + 1);	// aligned nts	
+
+		}
+	}
+	
+	if(to == from){
+		pattern.push_back(0); // gaps
+		
+	}
+	else{
+		pattern.push_back(frags[pt].aliPos - (frags[pt-1].aliPos + frags[pt-1].len - 1) - 1); // gaps
+		
+	}
+	
+	return 0;
+}
+
+
 int MsaSignature::maxSigStrLen = 0;
 

--- a/src/compgenepred.cc
+++ b/src/compgenepred.cc
@@ -691,7 +691,7 @@ void printMSA_printEC(ostream& os, vector<string>& speciesNames, RandSeqAccess* 
 	
 
 	// coordinate conversion from exon cand space to chromosome space (we want coo referred to the + strand because getSeq from RandSeqAccess requires so)
-	ec2Chr(ec->begin, ec->end, geneRange->getOffsets(sp), rsa->getChrLen(sp, seqID), geneRange->getStrand(sp), chrStart, chrEnd, true);
+	ec2Chr(ec->begin, ec->end, geneRange->getOffsets()[sp], rsa->getChrLen(sp, seqID), geneRange->getStrand(sp), chrStart, chrEnd, true);
 	
 	if(geneRange->getStrand(sp) == plusstrand){
 		if(isPlusExon(ec->type))

--- a/src/compgenepred.cc
+++ b/src/compgenepred.cc
@@ -730,7 +730,7 @@ void printMSA_printEC(ostream& os, vector<string>& speciesNames, RandSeqAccess* 
 
 		// coordinate conversion from exon cand space to chromosome space (in this case coordinates are referred to the strand the ec lies on
 		// because all methods dealing with the alignment usually require so)		
-		ec2Chr(ec->begin, ec->end, geneRange->getOffsets(sp), rsa->getChrLen(sp, seqID), geneRange->getStrand(sp), chrStartStranded, chrEndStranded, false);
+		ec2Chr(ec->begin, ec->end, geneRange->getOffsets()[sp], rsa->getChrLen(sp, seqID), geneRange->getStrand(sp), chrStartStranded, chrEndStranded, false);
 		printMSA_printEC_helper(os, geneRange, sp, speciesNames, rsa, chrStartStranded, chrEndStranded, as, expandUnaligned);
 		delete as;
 	}

--- a/src/compgenepred.cc
+++ b/src/compgenepred.cc
@@ -22,6 +22,17 @@
 #include <sys/stat.h>
 
 
+/*
+*   added by Giovanna Migliorelli 10.10.2019 
+*   headers for functions in charge of printing MSA associated with some OE
+*/
+void ec2Chr(int ecStart, int ecEnd, int offset, int chrLen, Strand strand, int& chrStart, int& chrEnd, bool referToPlus);
+void printMSA_printEC_helper(ostream& os, GeneMSA* geneRange, int sp, vector<string>& speciesNames, RandSeqAccess* rsa, int chrStart, int chrEnd, AnnoSequence* as, bool expandUnaligned);
+void printMSA_printEC(ostream& os, vector<string>& speciesNames, RandSeqAccess* rsa, GeneMSA* geneRange, int sp, ExonCandidate* ec, bool downcase, bool expandUnaligned);
+void printMSA(ostream& os, vector<string>& speciesNames, RandSeqAccess* rsa, GeneMSA* geneRange, OrthoExon& oe, bool extraInfo, bool expandUnaligned);
+
+
+
 CompGenePred::CompGenePred() : tree(Constant::treefile) {
 
     rsa = NULL;

--- a/src/compgenepred.cc
+++ b/src/compgenepred.cc
@@ -681,7 +681,6 @@ void printMSA_printEC_helper(ostream& os, GeneMSA* geneRange, int sp, vector<str
 	os << endl;
 }
 
-
 void printMSA_printEC(ostream& os, vector<string>& speciesNames, RandSeqAccess* rsa, GeneMSA* geneRange, int sp, ExonCandidate* ec, bool downcase, bool expandUnaligned){
 
 	int chrStart, chrEnd, chrStartStranded, chrEndStranded;


### PR DESCRIPTION
The first tool to support MSA contains printMSA, to print the MSA associated with some ortho exon. Before including it as a method of OrthoExon class it needs further testing. 