### PR TITLE
Solved a bug that made BLAST treat the whole file ncpus times

### DIFF
--- a/scripts/aa2nonred.pl
+++ b/scripts/aa2nonred.pl
@@ -200,7 +200,7 @@ if ( $CPU == 1 ) {
         my $pm = new Parallel::ForkManager($CPU);
         foreach ( @splitFiles ) {
             my $pid = $pm->start and next;
-            system("$BLAST_PATH/blastp -query $tempdbname -db $tempdbname > $_.blastout");
+            system("$BLAST_PATH/blastp -query $_ -db $tempdbname > $_.blastout");
             $pm->finish;
         }
         $pm->wait_all_children;


### PR DESCRIPTION
Hello,

While using the BRAKER pipeline to predict genes in my new genome, I noticed that aa2nonred.pl did the following:

After splitting the predicted proteins file made from GeneMark prediction, instead of treating each split file, the code makes BLAST treat the whole file ncpus times in parallel, making computing time and hard disk usage prohibitive with a large number of cpus. I solved it by changing:

`system("$BLAST_PATH/blastp -query $tempdbname -db $tempdbname > $_.blastout");`

into

`system("$BLAST_PATH/blastp -query $_ -db $tempdbname > $_.blastout");`

in the "blast that file against itself" part of the code.

The change made the code work as it looks like it was supposed to.

Best regards.