### PR TITLE
Hacky fix to file name length bug

### DIFF
--- a/auxprogs/homGeneMapping/src/main.cc
+++ b/auxprogs/homGeneMapping/src/main.cc
@@ -329,8 +329,8 @@ map<string,pair<string,string> > getFileNames (string listfile){
     map<string,pair<string, string> > filenames;
     ifstream ifstrm(listfile.c_str());
     if (ifstrm.is_open()){
-        char buf[256];
-	while(ifstrm.getline(buf,255)){
+        char buf[512];
+	while(ifstrm.getline(buf,511)){
 	    stringstream stm(buf);
             string species, genefile;
             if(stm >> species >> genefile){


### PR DESCRIPTION
If the sum of the length of the filenames >256 characters, the parser silently fails. Up this to 512.

Should this be an actual resizable vector?