### PR TITLE
fixed issue 112, segmentation fault in fastBlockSearch due to

### DIFF
--- a/include/pp_profile.hh
+++ b/include/pp_profile.hh
@@ -803,8 +803,12 @@ namespace PP {
 	    len = seqlen;
 	}
 	static void initSeq(string s) {
-	    sequence = s.c_str();
-	    len = s.length();
+            // Make a copy of the actual character array, as the
+            // string can be destroyed when the sequence is still needed.
+            len = s.length();
+            char *dna = new char[len + 1];
+            std::strcpy (dna, s.c_str());
+            sequence = dna;
 	}
     };
 

--- a/src/fastBlockSearch.cc
+++ b/src/fastBlockSearch.cc
@@ -238,6 +238,8 @@ int main(int argc, char* argv[]) {
 	cout << "Hits found in " << seqname << endl;
 	printBestResults(prfl, fastSearchResults, cutoff, columnCount, predictionStart);
 	cout << endl;
+        delete [] PP::DNA::sequence;
+        
 	if (predictionStart > 0 || predictionLen != MAX_SEQSIZE)
 	    break;
     }


### PR DESCRIPTION
char* sequence = currSeq.c_str() bug

The compiler has used the memory of the string while a char* copy of the contents were still used.