### PR TITLE
Optional sql features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ FROM ubuntu:18.04
 RUN apt-get update
 RUN apt-get install -y build-essential wget git autoconf
 
-# Install dependencies for AUGUSTUS
-RUN apt-get install -y libsqlite3-dev libmysql++-dev
-
 # Install dependencies for AUGUSTUS comparative gene prediction mode (CGP)
 RUN apt-get install -y libgsl-dev libboost-all-dev libsuitesparse-dev liblpsolve55-dev
+RUN apt-get install -y libsqlite3-dev libmysql++-dev
 
 # Install dependencies for  the optional support of gzip compressed input files
 RUN apt-get install -y libboost-iostreams-dev zlib1g-dev
@@ -50,6 +48,25 @@ RUN ./configure
 RUN make
 RUN make install
 ENV TOOLDIR="/root"
+
+# Install hal
+WORKDIR /root
+RUN wget http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz
+RUN tar xzf hdf5-1.10.1.tar.gz
+WORKDIR /root/hdf5-1.10.1
+RUN ./configure --enable-cxx
+RUN make && make install
+ENV PATH="${PATH}:/root/hdf5-1.10.1/hdf5/bin"
+WORKDIR /root
+RUN git clone https://github.com/benedictpaten/sonLib.git
+WORKDIR /root/sonLib
+RUN make
+WORKDIR /root
+RUN git clone https://github.com/ComparativeGenomicsToolkit/hal.git
+WORKDIR /root/hal
+ENV RANLIB=ranlib
+RUN make
+ENV PATH="${PATH}:/root/hal/bin"
 
 # Clone AUGUSTUS repository
 ADD / /root/augustus

--- a/HISTORY.TXT
+++ b/HISTORY.TXT
@@ -1,5 +1,5 @@
      - compile with CGP and ZIPINPUT support by default
-     - compile with SQLite and MySQL support for CGP (no longer optional)
+     - compile with SQLite and MySQL support for CGP (switch of by adding SQLite = false and MySQL = false to common.mk)
 List of changes from version 3.3.2 to 3.3.3 (until Sep 13th, 2019)
      - docker container
      - new script tfix_in_frame_stop_codon_genes.py that replaces genes where spliced in-frame stop codons were predicted

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ docker build -t augustus .
 ## Install dependencies
 
 The following dependencies are required for AUGUSTUS:
-  - libsqlite3-dev
-  - libmysql++-dev
 - For gzip compressed input:
  (set ZIPINPUT = false in [common.mk](common.mk) if this feature is not required or the required libraries are not available)
   - libboost-iostreams-dev
   - zlib1g-dev
 - For comparative AUGUSTUS (multi-species, CGP):
-  (Set COMPGENEPRED = false in [common.mk](common.mk) if this feature is not required or the required libraries are not available)
+  (set COMPGENEPRED = false in [common.mk](common.mk) if this feature is not required or the required libraries are not available)
   - libgsl-dev
   - libboost-all-dev
   - libsuitesparse-dev
   - liblpsolve55-dev
+  - libsqlite3-dev (add SQLITE = false to [common.mk](common.mk) if this feature is not required or the required library is not available)
+  - libmysql++-dev (add MYSQL = false to [common.mk](common.mk) if this feature is not required or the required library is not available)
 - For compiling bam2hints and filterBam:
   - libbamtools-dev
 - For compiling utrrnaseq:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following dependencies are required for AUGUSTUS:
   - libboost-iostreams-dev
   - zlib1g-dev
 - For comparative AUGUSTUS (multi-species, CGP):
-  (set COMPGENEPRED = false in [common.mk](common.mk) if this feature is not required or the required libraries are not available)
+  (set COMPGENEPRED = false in [common.mk](common.mk) if the libraries required by the CGP version are not available. Augustus can then only be run in single-genome mode, which is what most users need.)
   - libgsl-dev
   - libboost-all-dev
   - libsuitesparse-dev

--- a/auxprogs/homGeneMapping/Dockerfile
+++ b/auxprogs/homGeneMapping/Dockerfile
@@ -21,14 +21,15 @@ RUN make
 WORKDIR /root
 RUN git clone https://github.com/ComparativeGenomicsToolkit/hal.git
 WORKDIR /root/hal
+ENV RANLIB=ranlib
 RUN make
 ENV PATH="${PATH}:/root/hal/bin"
 
 # Install dependencies for homGeneMapping
 RUN apt-get update
 RUN apt-get install -y libgsl-dev liblpsolve55-dev
-RUN apt-get install -y libsqlite3-dev
-RUN apt-get install -y libboost-all-dev libboost-iostreams-dev
+RUN apt-get install -y libsqlite3-dev  libmysql++-dev
+RUN apt-get install -y libboost-all-dev
 
 # Clone AUGUSTUS repository
 WORKDIR /root
@@ -44,6 +45,7 @@ ENV PATH="${PATH}:/root/Augustus/bin"
 # Build homGeneMapping
 ADD / /root/Augustus/auxprogs/homGeneMapping
 WORKDIR /root/Augustus/auxprogs/homGeneMapping/
+RUN make clean
 RUN make
 
 # Test homGeneMapping

--- a/auxprogs/homGeneMapping/Makefile
+++ b/auxprogs/homGeneMapping/Makefile
@@ -9,7 +9,7 @@ all:
 clean:
 	(rm -rf test; cd src; make clean)
 
-test:
+test:   all
 	rm -rf test
 	mkdir -p test
 	# test with hints

--- a/auxprogs/homGeneMapping/README.TXT
+++ b/auxprogs/homGeneMapping/README.TXT
@@ -20,7 +20,7 @@ alignment of the genomes and prints a summary for each gene, e.g.
 * HAL Tools (available at https://github.com/ComparativeGenomicsToolkit/hal)
 * Boost graph library for option --printHomologs that clusters transcripts into groups of homologs
   Install the package libboost-all-dev with your package manager
-  (optional: set BOOST = false in src/Makefile if the Boost library is unavailable and option --printHomologs is not required)
+  (optional: add BOOST = false to common.mk if the Boost library is unavailable and option --printHomologs is not required)
 * SQLite library for option --dbaccess that enables the retrieval hints from a database:
   Install the package libsqlite3-dev with your package manager or 
   download the SQLite source code from http://www.sqlite.org/download.html 
@@ -35,7 +35,8 @@ alignment of the genomes and prints a summary for each gene, e.g.
    If you encounter an "SQLite header and source version mismatch" error, try
 
    > ./configure --disable-dynamic-extensions --enable-static --disable-shared
-
+  (optional: add SQLITE = false to common.mk if the SQLite library is unavailable and option --dbaccess is not required)
+  
 From within the auxprogs/homGeneMapping directory, type "make"
 
 

--- a/auxprogs/homGeneMapping/include/genome.hh
+++ b/auxprogs/homGeneMapping/include/genome.hh
@@ -15,7 +15,10 @@
 
 //project includes
 #include "gene.hh"
+
+#ifdef M_SQLITE
 #include "sqliteDB.hh"
+#endif
 
 #ifdef BOOST
 #include <boost/graph/adjacency_list.hpp>
@@ -61,8 +64,9 @@ public:
     void parseGTF(std::string gtffilename);                          // reads a gene file in gtf format
     void parseExtrinsicGFF(std::string gfffilename);                 // reads a hints file in gff format
     void insertHint(std::string seqname, long int start, long int end, Strand strand, std::string esource, int mult, int frame, std::string f_type);
+#ifdef M_SQLITE
     void getDbHints(SQLiteDB &db);
-
+#endif
     //void printGFF(std::string outdir, std::vector<Genome> &genomes, bool detailed=false); // output a gene in gtf format with
     void printBed();
     void readBed(Genome &other);

--- a/auxprogs/homGeneMapping/src/Makefile
+++ b/auxprogs/homGeneMapping/src/Makefile
@@ -1,8 +1,16 @@
 #
 # Makefile for homGeneMapping
-#
-# comment this flag to disable the usage of the Boost graph library, the option --printHomologs will not be available
-BOOST = true
+
+include ../../../common.mk
+
+# set SQLITE = false in common.mk to disable the usage of the SQLite library, option --dbaccess will not be available
+# set BOOST = false in common.mk to disable the usage of the Boost graph library, the option --printHomologs will not be available
+BOOST ?= true
+
+ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE)) # if COMPGENEPRED is not defined or not contains 0, false, False or FALSE
+# comment this flag to disable database access for retrieval of hints, the option --dbaccess will not be available
+	SQLITE ?= true
+endif
 
 CC      = g++
 
@@ -12,12 +20,18 @@ CC      = g++
 CFLAGS := -Wall -Wno-sign-compare -ansi -pedantic -std=c++0x -pthread -O2 ${CFLAGS} # -DDEBUG -g -ggdb -pg
 
 INCLS	= -I../include
-LIBS	= -lsqlite3 # add the sqlite library path here, if sqlite is not install system-wide
-OBJS	= gene.o genome.o sqliteDB.o
+LIBS	=
+OBJS	= gene.o genome.o
 
-ifdef BOOST
+ifeq (,$(findstring $(BOOST),0 false False FALSE)) # if BOOST is not defined or not contains 0, false, False or FALSE
 	CFLAGS += -DBOOST
 	INCLS +=  # add the boost include path here, if boost ist not installed system-wide
+endif
+
+ifneq (,$(findstring $(SQLITE),1 true True TRUE)) # if SQLITE is defined and contains 1, true, True or TRUE
+	LIBS    += -lsqlite3 # add the sqlite library path here, if sqlite is not install system-wide
+	OBJS    += sqliteDB.o
+	CFLAGS  += -DM_SQLITE
 endif
 
 all: homGeneMapping

--- a/auxprogs/homGeneMapping/src/genome.cc
+++ b/auxprogs/homGeneMapping/src/genome.cc
@@ -37,10 +37,12 @@ void Genome::parse(string genefile, string hintsfile, string dbfile){
     parseGTF(genefile);
     if(!hintsfile.empty()) // read hints file if specified
 	parseExtrinsicGFF(hintsfile);
+#ifdef M_SQLITE
     if(!dbfile.empty()){
 	SQLiteDB db = SQLiteDB(dbfile.c_str());
 	getDbHints(db);
     }
+#endif
     printBed(); // print sequence coordinates, that need to be mapped to the other genomes, to file
 }
 
@@ -830,6 +832,7 @@ void Genome::insertHint(string seqname, long int start, long int end, Strand str
     }    
 }
 
+#ifdef M_SQLITE
 void Genome::getDbHints(SQLiteDB &db){
 
     try{
@@ -858,4 +861,5 @@ void Genome::getDbHints(SQLiteDB &db){
 	throw ProjectError("failed retrieving hints from DB for " + name + "."  + "\n");
     }
 }
+#endif
 		

--- a/auxprogs/homGeneMapping/src/main.cc
+++ b/auxprogs/homGeneMapping/src/main.cc
@@ -138,6 +138,14 @@ int main( int argc, char* argv[] ){
 	    printUsage();
 	    exit(1);
 	}
+#ifndef M_SQLITE
+	if (!dbfile.empty()){
+	    throw ProjectError("The option --dbaccess requires the SQLite library.\n"
+                               "Please install the SQLite library, e.g. using the APT package manager\n\n"
+                               "sudo apt-get install libsqlite3-dev\n\n"
+                               "Then edit the Makefile by setting the flag SQLITE = true and recompile homGeneMapping.\n");
+	}
+#endif
 	if(maxCpus < 1){
 	    maxCpus = 1;
 	    cerr << "number of cpus must be at least 1. Proceeding with --cpus=1" << endl; 
@@ -303,6 +311,7 @@ OPTIONS:\n\
                               a separate tool 'load2sqlitedb' is provided. For more information, see the documentation in\n\
                               README-cgp.txt (section 8a+b) in the Augustus package. If both a database and hint files in 'gtffilenames.tbl'\n\
                               are specified, hints are retrieved from both sources.\n\
+                              This option requires the SQLite3 library.\n\
 \n\
 example:\n\
 homGeneMapping --noDupes --halLiftover_exec_dir=~/tools/progressiveCactus/submodules/hal/bin --gtfs=gtffilenames.tbl --halfile=msca.hal\n\

--- a/common.mk
+++ b/common.mk
@@ -8,5 +8,7 @@ AUGVERSION = 3.3.3
 ZIPINPUT = true
 
 # set COMPGENEPRED to false if you do not require the comparative gene prediction mode (CGP) or
-# the required libraries libgsl-dev, libboost-all-dev, libsuitesparse-dev and liblpsolve55-dev are not available
+# the required libraries 
+# libgsl-dev, libboost-all-dev, libsuitesparse-dev, liblpsolve55-dev, libmysql++-dev and libsqlite3-dev 
+# are not available
 COMPGENEPRED = true

--- a/docs/tutorial-cgp/index.html
+++ b/docs/tutorial-cgp/index.html
@@ -70,6 +70,18 @@ sudo apt-get install build-essential
 sudo apt-get install libsuitesparse-dev liblpsolve55-dev
 </pre>
 </li>
+<li><a href="https://www.mysql.com">MySQL</a> (open-source relational database management system (RDBMS))<br>
+<span class="assignment">Install</span> via package manager, on UBUNTU/Debian linux</span>
+<pre class="code">
+sudo apt-get install libmysql++-dev
+</pre>
+</li>
+<li><a href="https://www.sqlite.org">SQLite</a> (relational database management system (RDBMS))<br>
+<span class="assignment">Install</span> via package manager, on UBUNTU/Debian linux</span>
+<pre class="code">
+sudo apt-get install libsqlite3-dev
+</pre>
+</li>
 </ul>
 </div>
 For convenience, you may want to , <span class="assignment">run</span> or <span class="assignment">add</span> this to your .bashrc file

--- a/docs/tutorial2018/README_augustus.TXT
+++ b/docs/tutorial2018/README_augustus.TXT
@@ -156,7 +156,6 @@ docs
 
 The following dependencies are required for AUGUSTUS:
    - build-essential, wget, git, autoconf (sudo apt-get install build-essential wget git autoconf)
-   - libsqlite3-dev and libmysql++-dev (sudo apt-get install libsqlite3-dev libmysql++-dev)
   - libraries for gzip compressed input (set ZIPINPUT = false in common.mk if this feature is not required or the required libraries are not available):
    - Boost C++ Libraries: libboost-iostreams-dev (on Ubuntu: sudo apt-get install libboost-iostreams-dev)
    - zlib library for compression methods. Download from http://www.zlib.net/ or install via package manager (sudo apt-get install zlib1g-dev).
@@ -164,7 +163,9 @@ The following dependencies are required for AUGUSTUS:
    - GNU scientific library (for eigen decompositions of matrices, sudo apt-get install libgsl-dev)
    - Boost C++ Library: sudo apt-get install libboost-all-dev (at least version 1.45 from Nov. 2010)
    - integer linear program solver liblpsolve55-dev: sudo apt-get install libsuitesparse-dev liblpsolve55-dev
-
+   - libsqlite3-dev (sudo apt-get install libsqlite3-dev) (add SQLITE = false to common.mk if this feature is not required or libsqlite3-dev is not available)
+   - libmysql++-dev (sudo apt-get install libmysql++-dev) (add MYSQL = false to common.mk if this feature is not required or libmysql++-dev is not available)
+   
 Compiling bam2hints and filterBam requires:
 
    - The packages bamtools and libbamtools-dev

--- a/include/pp_simscore.hh
+++ b/include/pp_simscore.hh
@@ -1,10 +1,17 @@
 /*
  * Name:    pp_simscore.hh
+ * 
+ * License: Artistic License, see file LICENSE.TXT or 
+ *          https://opensource.org/licenses/artistic-license-1.0
+ * 
  * Project: similarity-score algorithm for block-profile and protein sequence
  * with intron information
  * Author:  Lars Gabriel
  *
  */
+
+#ifndef __PP_SIMSCORE_HH
+#define __PP_SIMSCORE_HH
 
 #include <iostream>
 #include <fstream>
@@ -13,9 +20,6 @@
 #include <string>
 #include "properties.hh"
 #include "pp_profile.hh"
-
-#include <sqlite3.h>
-
 
  namespace SS {
     /**
@@ -357,3 +361,4 @@
     };
 }
 //namespace SS
+#endif

--- a/include/randseqaccess.hh
+++ b/include/randseqaccess.hh
@@ -17,8 +17,13 @@
 #include <vector>
 #include <cstring>
 
+#ifdef M_MYSQL
 #include <mysql++.h>
+#endif
+
+#ifdef M_SQLITE
 #include "sqliteDB.hh"
+#endif
 
 /**
  * @brief SpeciesCollection holds all extrinsic evidence given for the species.
@@ -125,6 +130,7 @@ protected:
 
 };
 
+#ifdef M_MYSQL
 class MysqlAccess : public DbSeqAccess {
 public:
     MysqlAccess(vector<string> s = vector<string>()) : DbSeqAccess(s){
@@ -149,6 +155,9 @@ private:
     mysqlpp::Connection con;
     vector<string> db_information;
 };
+#endif // M_MYSQL
+
+#ifdef M_SQLITE
 
 /**
  * @brief Random access to sequence segments through a database.
@@ -168,5 +177,6 @@ private:
     SQLiteDB db;
     map<string,string> filenames;
 };
+#endif // M_SQLITE
 
 #endif  // _RANDSEQACCESS

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,21 +9,21 @@ CXX	= g++
 #        - The order of object files in $(OBJS) IS IMPORTANT (see lldouble.hh)
 CXXFLAGS := -Wall -Wno-sign-compare -pedantic -g -ggdb -O3 ${CXXFLAGS} #-DDEBUG -g -ggdb -pg -DDEBUG_STATES
 
-ifeq (,$(findstring $(ZIPINPUT),0 false False FALSE))
+ifeq (,$(findstring $(ZIPINPUT),0 false False FALSE))  # if ZIPINPUT is not defined or is something else than 0, false, False or FALSE
 	CXXFLAGS += -DZIPINPUT
 	LIBS    = -lboost_iostreams
 endif
 
-ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE))
-	CXXFLAGS += -std=c++11 -DCOMPGENEPRED
-endif
 INCLS	= -I../include
 
 OBJS	= genbank.o properties.o pp_profile.o pp_hitseq.o pp_scoring.o statemodel.o namgene.o \
  types.o gene.o evaluation.o motif.o geneticcode.o hints.o extrinsicinfo.o projectio.o \
  intronmodel.o exonmodel.o igenicmodel.o utrmodel.o merkmal.o vitmatrix.o lldouble.o mea.o graph.o \
  meaPath.o exoncand.o randseqaccess.o fasta.o ncmodel.o
-ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE))
+ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE))  # if COMPGENEPRED is not defined or is something else than 0, false, False or FALSE
+	SQLITE   ?= true
+	MYSQL    ?= true
+	CXXFLAGS += -std=c++11 -DCOMPGENEPRED
 	OBJS += parser/parse.o scanner/lex.o genomicMSA.o geneMSA.o contTimeMC.o compgenepred.o phylotree.o orthograph.o orthoexon.o alignment.o speciesgraph.o codonMSA.o train_logReg_param.o
 	LIBS += -lgsl -lgslcblas # for matrix exponentiation that is required in comparative gene finding
 	LIBS += -llpsolve55 -lcolamd -ldl # for mixed integer linear programming (alignment.cc)
@@ -34,21 +34,27 @@ TOBJS	= commontrain.o igenictrain.o introntrain.o exontrain.o utrtrain.o # conte
 PROGR	= augustus etraining prepareAlign fastBlockSearch pp_simScore
 INFO    = cxxflags
 
-# MySQL support
-# replace RUNTIME_LIBPATH with your own run-time libpath if mysql++ is not installed system-wide, e.g.
-# RUNTIME_LIBPATH = -Wl,-rpath=/home/mario/augustus/trunks/mysql++/mysql++-3.1.0/lib
-RUNTIME_LIBPATH =
-INCLS	+= -I/usr/include/mysql -I/usr/include/mysql++ # the path to mysql++ may have to be adjusted
-LIBS 	+=  -lmysqlclient -lmysqlpp ${RUNTIME_LIBPATH} # -L/usr/local/lib/libmysqlpp.so.3.1.0
-PROGR   += load2db getSeq
+ifneq (,$(findstring $(MYSQL),1 true True TRUE)) # if MYSQL is defined and contains 1, true, True or TRUE
+	# MySQL support
+	# replace RUNTIME_LIBPATH with your own run-time libpath if mysql++ is not installed system-wide, e.g.
+	# RUNTIME_LIBPATH = -Wl,-rpath=~/augustus/trunks/mysql++/mysql++-3.1.0/lib
+	RUNTIME_LIBPATH =
+	INCLS    += -I/usr/include/mysql -I/usr/include/mysql++ # the path to mysql++ may have to be adjusted
+	LIBS     += -lmysqlclient -lmysqlpp ${RUNTIME_LIBPATH} # -L/usr/local/lib/libmysqlpp.so.3.1.0
+	CXXFLAGS += -DM_MYSQL
+	PROGR    += load2db getSeq
+endif
 
-# SQLite support
-LIBS	  += -lsqlite3
-OBJS	  += sqliteDB.o
-PROGR     += load2sqlitedb getSeq
+ifneq (,$(findstring $(SQLITE),1 true True TRUE)) # if SQLITE is defined and contains 1, true, True or TRUE
+	# SQLite support
+	LIBS      += -lsqlite3
+	OBJS      += sqliteDB.o
+	CXXFLAGS  += -DM_SQLITE
+	PROGR     += load2sqlitedb getSeq
+endif
 
 ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE))
-PROGR     += espoca
+    PROGR     += espoca
 endif
 
 all: $(OBJS) $(TOBJS) $(DUMOBJS) $(PROGR) info

--- a/src/compgenepred.cc
+++ b/src/compgenepred.cc
@@ -43,13 +43,23 @@ CompGenePred::CompGenePred() : tree(Constant::treefile) {
 	string dbaccess = Constant::dbaccess;
 	if (dbaccess.find(',') != string::npos){ // assuming mysql access
 	    cout << "# assuming a MySQL database" << endl;
+#ifdef M_MYSQL
 	    rsa = new MysqlAccess(speciesNames);
+#else
+	    throw ProjectError("Database access not possible with this compiled version. Please recompile with flag MYSQL = true added to common.mk.");
+#endif
+
 	}
 	else if(dbaccess.find('.') != string::npos){ // assuming sqlite access
 	    cout << "# assuming an SQLite database" << endl;
 	    if(Constant::speciesfilenames.empty())
 		throw ProjectError("Missing parameter speciesfilenames.");
+#ifdef M_SQLITE
 	    rsa = new SQLiteAccess(dbaccess.c_str(), speciesNames);
+#else
+	    throw ProjectError("Database access not possible with this compiled version. Please recompile with flag SQLITE = true added to common.mk.");
+#endif
+	    
 	}
 	else{
 	    throw ProjectError("cannot determine the type of database.\n\

--- a/src/getSeq.cc
+++ b/src/getSeq.cc
@@ -106,7 +106,13 @@ int main( int argc, char* argv[] ){
 
     if (Constant::dbaccess.find(',') != string::npos){ // assuming mysql access
 	cerr << "assuming a MySQL database" << endl;
+#ifdef M_MYSQL
 	rsa = new MysqlAccess;
+#else
+	cerr << "Database access not possible with this compiled version. Please recompile with flag MYSQL = true added to common.mk." << endl;
+	exit(1);
+#endif
+	
     }
     else if(Constant::dbaccess.find('.') != string::npos){ // assuming sqlite access
 	cerr << "assuming an SQLite database" << endl;
@@ -114,7 +120,12 @@ int main( int argc, char* argv[] ){
 	    cerr << "Missing parameter speciesfilenames." << endl;
 	    exit(1);
 	}
+#ifdef M_SQLITE
 	rsa = new SQLiteAccess(Constant::dbaccess.c_str());
+#else
+	cerr <<"Database access not possible with this compiled version. Please recompile with flag SQLITE = true set in common.mk." << endl;
+	exit(1);
+#endif
     }
 
     try{

--- a/src/randseqaccess.cc
+++ b/src/randseqaccess.cc
@@ -16,8 +16,10 @@
 #include <fstream>
 #include <types.hh>
 
+#ifdef M_MYSQL
 #include <table_structure.h>
 #include <query.h>
+#endif
 
 int SpeciesCollection::groupCount = 1;
 
@@ -386,6 +388,7 @@ DbSeqAccess::DbSeqAccess(vector<string> s){
     }
 }
 
+#ifdef M_MYSQL
 void MysqlAccess::open(){
     dbaccess = Constant::dbaccess;
     split_dbaccess();
@@ -743,6 +746,9 @@ int MysqlAccess::get_region_coord(int seq_region_id,int start,int end,vector<T> 
 //    return seqlist;
 //}
 
+#endif // M_MYSQL
+
+#ifdef M_SQLITE
 AnnoSequence* SQLiteAccess::getSeq(string speciesname, string chrName, int start, int end, Strand strand){
     int seq_start, seq_end;
     streampos file_start;
@@ -869,3 +875,4 @@ SequenceFeatureCollection* SQLiteAccess::getFeatures(string speciesname, string 
     fc->hasHintsFile = true;
     return sfc;
 }
+#endif // M_SQLITE


### PR DESCRIPTION
use MySQL and SQLite by default only in CGP mode and add option to turn them explicitly on or off

- the MySQL and SQLite libraries are not used when COMPGENEPRED = false in common.mk
- Independent of the COMPGENEPRED setting, MySQL and SQLite may be switched on or off by adding MYSQL = true  and SQLITE = true (or false) to common.mk
- the MYSQL and SQLite flags are not contained in common.mk in the git repository
- the previously separate SQLITE flag in auxprogs/homGeneMapping/src/Makefile is removed and the flag in common.mk is used or if not set the COMPGENEPRED setting
- the SQLite library in pp_simscore.hh seemed to be not in use and was removed
