### PR TITLE
Fix path to README-cgp

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,6 +1,6 @@
 # About AUGUSTUS
 
-AUGUSTUS is a gene prediction program written by Mario Stanke, Oliver Keller, Stefanie König, Lizzy Gerischer and Katharina Hoff. It can be used as an ab initio program, which means it bases its prediction purely on the sequence. AUGUSTUS may also incorporate hints on the gene structure coming from extrinsic sources such as EST, MS/MS, protein alignments and syntenic genomic alignments. Since version 3.0 AUGUSTUS can also predict the genes simultaneously in several aligned genomes (see [README-cgp.txt](../README-cgp.txt)). Currently, AUGUSTUS has been trained for predicting genes in: 
+AUGUSTUS is a gene prediction program written by Mario Stanke, Oliver Keller, Stefanie König, Lizzy Gerischer and Katharina Hoff. It can be used as an ab initio program, which means it bases its prediction purely on the sequence. AUGUSTUS may also incorporate hints on the gene structure coming from extrinsic sources such as EST, MS/MS, protein alignments and syntenic genomic alignments. Since version 3.0 AUGUSTUS can also predict the genes simultaneously in several aligned genomes (see [README-cgp.md](../README-cgp.md)). Currently, AUGUSTUS has been trained for predicting genes in: 
 
 - Homo sapiens (human), 
 - Drosophila melanogaster (fruit fly), 


### PR DESCRIPTION
The commit fixes the path to README-cgp file, which is broken. There is no file `README-cgp.txt`, but `README-cgp.md`.