### PR TITLE
Update bam2wig dependencies to require htslib only

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**
+!Makefile
+!auxprogs
+!config
+!common.mk
+!examples/example.fa
+!include
+!scripts
+!src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 
 # Install required packages
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get install -y build-essential wget git autoconf
 
 # Install dependencies for AUGUSTUS comparative gene prediction mode (CGP)
-RUN apt-get install -y libgsl-dev libboost-all-dev libsuitesparse-dev liblpsolve55-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgsl-dev libboost-all-dev libsuitesparse-dev liblpsolve55-dev
 RUN apt-get install -y libsqlite3-dev libmysql++-dev
 
 # Install dependencies for  the optional support of gzip compressed input files
@@ -15,39 +15,14 @@ RUN apt-get install -y libboost-iostreams-dev zlib1g-dev
 # Install dependencies for bam2hints and filterBam 
 RUN apt-get install -y libbamtools-dev
 
-# Install additional dependencies for htslib and samtools
-RUN apt-get install -y libbz2-dev liblzma-dev
-RUN apt-get install -y libncurses5-dev
+# Install samtools
+RUN apt-get install samtools
 
 # Install additional dependencies for bam2wig
-RUN apt-get install -y libssl-dev libcurl3-dev
+RUN apt-get install -y libhts-dev
 
 # Install additional dependencies for homgenemapping and utrrnaseq
 RUN apt-get install -y libboost-all-dev
-
-# Build bam2wig dependencies (htslib, bfctools, samtools)
-RUN git clone https://github.com/samtools/htslib.git /root/htslib
-WORKDIR "/root/htslib"
-RUN autoheader
-RUN autoconf
-RUN ./configure
-RUN make
-RUN make install
-RUN git clone https://github.com/samtools/bcftools.git /root/bcftools
-WORKDIR "/root/bcftools"
-RUN autoheader
-RUN autoconf
-RUN ./configure
-RUN make
-RUN make install
-RUN git clone https://github.com/samtools/samtools.git /root/samtools
-WORKDIR "/root/samtools"
-RUN autoheader
-RUN autoconf -Wno-syntax
-RUN ./configure
-RUN make
-RUN make install
-ENV TOOLDIR="/root"
 
 # Install hal
 WORKDIR /root
@@ -73,8 +48,7 @@ ADD / /root/augustus
 
 # Build AUGUSTUS
 WORKDIR "/root/augustus"
-RUN make clean
-RUN make
+RUN make HTSLIBS='-lhts'
 RUN make install
 ENV PATH="/root/augustus/bin:${PATH}"
 

--- a/auxprogs/bam2wig/Makefile
+++ b/auxprogs/bam2wig/Makefile
@@ -1,6 +1,6 @@
 # Makefile of bam2wig
 #
-# NOTE: Modify the variable TOOLDIR according to where your samtools/htslib/bcftools software has been installed
+# NOTE: Modify the variable TOOLDIR according to where your htslib software has been installed
 # 
 # License: Artistic License, see file LICENSE.TXT or 
 #          https://opensource.org/licenses/artistic-license-1.0
@@ -8,24 +8,21 @@
 
 ifndef TOOLDIR
 	TOOLDIR=$(HOME)/tools
-# replace with your own parent directory of samtools, htslib, bcftools
+# replace with your own parent directory of htslib
 # if TOOLDIR is not specified as environment variable
 endif
 
 PROGRAM = bam2wig
 SOURCES = $(PROGRAM)
 OBJECTS = $(SOURCES:.c=.o)
-SAMTOOLS=$(TOOLDIR)/samtools
 HTSLIB=$(TOOLDIR)/htslib
-BCFTOOLS=$(TOOLDIR)/bcftools
-INCLUDES=-I$(SAMTOOLS) -I. -I$(HTSLIB) -I$(BCFTOOLS)
-VPATH=$(SAMTOOLS)
-LIBS=$(SAMTOOLS)/libbam.a $(HTSLIB)/libhts.a -lcurses -lm -lz -lpthread -lcurl -lssl -lcrypto
+INCLUDES=-I. -I$(HTSLIB) -lbz2 -llzma
+HTSLIBS?=$(HTSLIB)/libhts.a -lm -lz -lpthread -lcurl -lssl -lcrypto
 CFLAGS:=-Wall -O2 $(INCLUDES) $(CFLAGS)
 CC?=gcc
 
 $(PROGRAM) : bam2wig.o
-	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS) -lbz2 -llzma
+	$(CC) $(LDFLAGS) $^ -o $@ $(HTSLIBS)
 	mkdir -p ../../bin
 	cp bam2wig ../../bin/bam2wig
 

--- a/auxprogs/bam2wig/README.txt
+++ b/auxprogs/bam2wig/README.txt
@@ -1,14 +1,11 @@
 Installation instructions:
 
 0. Install dependencies:
-   * bcftools
    * htslib
-   * samtools
-  You find those tools at https://github.com/samtools . bam2wig has been tested with samtools 0.2.0-rc7
+  You find this library at https://github.com/samtools/htslib .
 
-  We recommend that you install all three tools into one directory that we will further refer to as the
-  TOOLDIR. For example, you can install all tools into your home directory, which will result into
-  three folders in your home directory: bcftools, htslib and samtools.
+  We recommend that you install htslib in one directory that we will further refer to as the
+  TOOLDIR.
 
   Installation example:
 
@@ -19,23 +16,6 @@ Installation instructions:
   ./configure
   make
   sudo make install
-  cd ..
-  git clone https://github.com/samtools/bcftools.git
-  cd bcftools
-  autoheader
-  autoconf
-  ./configure
-  make
-  sudo make install
-  cd ..
-  git clone https://github.com/samtools/samtools.git
-  cd samtools
-  autoheader
-  autoconf -Wno-syntax
-  ./configure
-  make
-  sudo make install
-  cd ..
 
 1. Export TOOLDIR path
 


### PR DESCRIPTION
This PR replaces https://github.com/Gaius-Augustus/Augustus/pull/152 ; rather than removing bam2wig completely (which is not desirable for all use cases, as it's more efficient than bamToWig.py), this PR provides modifications that make it easier to build; specifically, only htslib (>= 1.10.0) is required---and in the Dockerfile, this can be provided via ubuntu 20.04 package---rather than also requiring (source builds of) bcftools and samtools.