### PR TITLE
Compilation with old gcc fails if compgenepred = false #154

### DIFF
--- a/include/contTimeMC.hh
+++ b/include/contTimeMC.hh
@@ -13,6 +13,7 @@
 #include "matrix.hh"
 
 // standard C/C++ includes
+#include <cmath>
 #include <iostream>
 #include <gsl/gsl_matrix.h>
 #include <gsl/gsl_eigen.h>
@@ -46,7 +47,7 @@ public:
     virtual void addBranchLength(double b)=0; //add new branch length b and matrix P(b)
 
     double getPi(int i) const {return pi[i];}  //equilibrium frequency of state i
-    double getLogPi(int i) const {return log(getPi(i));}
+    double getLogPi(int i) const {return std::log(getPi(i));}
 
     gsl_matrix *getSubMatrixQ(int u){ return allQs[u]; }
     

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ CXX?=g++
 # Notes: - "-Wno-sign-compare" eliminates a high number of warnings (see footnote below). Please adopt
 #          a strict signed-only usage strategy to avoid mistakes since we are not warned about this.
 #        - The order of object files in $(OBJS) IS IMPORTANT (see lldouble.hh)
-CXXFLAGS := -Wall -Wno-sign-compare -pedantic -g -ggdb -O3 ${CXXFLAGS} #-DDEBUG -g -ggdb -pg -DDEBUG_STATES
+CXXFLAGS := -Wall -Wno-sign-compare -pedantic -g -ggdb -O3 -std=c++11 ${CXXFLAGS} #-DDEBUG -g -ggdb -pg -DDEBUG_STATES
 
 ifeq (,$(findstring $(ZIPINPUT),0 false False FALSE))  # if ZIPINPUT is not defined or is something else than 0, false, False or FALSE
 	CPPFLAGS += -DZIPINPUT
@@ -30,7 +30,6 @@ OBJS	= genbank.o properties.o pp_profile.o pp_hitseq.o pp_scoring.o statemodel.o
 ifeq (,$(findstring $(COMPGENEPRED),0 false False FALSE))  # if COMPGENEPRED is not defined or is something else than 0, false, False or FALSE
 	SQLITE   ?= true
 	MYSQL    ?= true
-	CXXFLAGS += -std=c++11
 	CPPFLAGS += -DCOMPGENEPRED
 	OBJS += parser/parse.o scanner/lex.o genomicMSA.o geneMSA.o contTimeMC.o codonevo.o compgenepred.o phylotree.o orthograph.o orthoexon.o alignment.o speciesgraph.o codonMSA.o train_logReg_param.o tokenizer.o
 	LIBS += -lgsl -lgslcblas # for matrix exponentiation that is required in comparative gene finding


### PR DESCRIPTION
set c++11 as C++ standard for augustus even in none comparative gene prediction mode and resolve #154 