### PR TITLE
Auto aug script bugfixes

### DIFF
--- a/scripts/autoAug.pl
+++ b/scripts/autoAug.pl
@@ -461,12 +461,13 @@ sub construct_training_set{
 	
 	my $abortString;
 	$abortString = "\nFailed to execute, possible reasons could be:\n";
-	$abortString.= "1. There is already a database named \"$pasaDBname\" in your mysql host.\n";
+	$abortString.= "1. There is already a database named \"$pasaDBname\" on your mysql host.\n";
 	$abortString.= "2. The software \"slclust\" is not installed correctly, try to install it";
 	$abortString.= " again (see the details in the PASA documentation).\n";
-	$abortString.= "3. The fasta headers in cDNA or genome file were not unique.\n";
-	$abortString.= "Inspect $trainDir/pasa/Launch_PASA_pipeline.stderr for PASA error messages.\n";
-	
+	$abortString.= "3. Fasta headers in cDNA or genome file were not unique.\n";
+	$abortString.= "4. Fasta headers in cDNA file contains square brackets, commas or other non-letter or non-number characters.\n";
+	$abortString.= "2. Fasta headers in cDNA file were too long (max 90 characters)(the sequence name up to the first space).\n";
+	$abortString.= "Inspect $trainDir/pasa/Launch_PASA_pipeline.stderr for PASA error messages.\n";	
 	print "2 Executing the Alignment Assembly: \"$perlCmdString\" ".(scalar localtime())." ..." if ($verbose>=2);
 	system("$perlCmdString")==0 or die ("$abortString");
 	print " Finished ".(scalar localtime())."\n" if ($verbose>=2);

--- a/scripts/autoAugPred.pl
+++ b/scripts/autoAugPred.pl
@@ -208,7 +208,6 @@ if($noninteractive){
             }
       }
 	    print "1 done with augustus jobs\n" if ($verbose >= 1);
-	    continue_aug($shellDir, $utr, $hints);
 	} else {
 	    print "\nPlease start the augustus jobs $workDir/shells/aug* manually now.\n";
 	    print "Either by running them sequentially on a single PC or by submitting ". 

--- a/scripts/autoAugPred.pl
+++ b/scripts/autoAugPred.pl
@@ -37,7 +37,7 @@ my $genome;              # fasta file
 my $cwd=cwd();           # current directory
 my $positionWD=$cwd;     # position where working directory placed, default: current working directory
 my $workDir;             # working directory
-my $splitDir;            # where splited contigs stored
+my $splitDir;            # where split contigs stored
 my $shellDir;            #
 my $continue;
 my $noninteractive;
@@ -69,13 +69,10 @@ Usage:
 autoAugPred.pl [OPTIONS] --genome=genome.fa --species=sname
 autoAugPred.pl [OPTIONS] --genome=genome.fa --species=sname --hints=hintsfile 
 
---genome=genome.fa             fasta file with DNA sequences for training
-
---species=sname                species name as used by AUGUSTUS
-
---continue                     after cluster jobs are finished, continue to compile prediction sets
-
 options:
+--genome=genome.fa             fasta file with DNA sequences for training
+--species=sname                species name as used by AUGUSTUS
+--continue                     after cluster jobs are finished, continue to compile prediction sets
 --useexisting                  use and change the present config and parameter files if they exist for 'species'
 --singleCPU                    run sequentially on a single CPU instead of parallel jobs on a cluster
 --cpus=n                       n is the number of CPUs to use (default: 1), if cpus > 1 install Parallel::ForkManager for better performance
@@ -165,7 +162,7 @@ if($noninteractive){
             for (my $i=1; $i <= $splitN; $i++){
                 print "2 running aug$i ".(scalar localtime())." ..." if ($verbose >= 2);
                 system ("./aug$i");
-                print " Finished! ".(scalar localtime())."\n" if ($verbose >2);
+                print " Finished! ".(scalar localtime())."\n" if ($verbose >= 2);
             }
         }
         else {
@@ -182,7 +179,7 @@ if($noninteractive){
                     my $pid = $pm->start and next; # fork and return the pid for the child:
                     print "2 running aug$i parallel ".(scalar localtime())." ...\n" if ($verbose >= 2);
                     system ("./aug$i");
-                    print " Finished aug$i! ".(scalar localtime())."\n" if ($verbose >2);
+                    print "2 finished aug$i ".(scalar localtime())."\n" if ($verbose >= 2);
                     $pm->finish; # terminate the child process
                 }
                 $pm->wait_all_children;
@@ -197,7 +194,7 @@ if($noninteractive){
                     $cmdString .= "wait ";
                     print "2 running $cmdString ".(scalar localtime())." ..." if ($verbose >= 2);
                     system ($cmdString);
-                    print " Finished! ".(scalar localtime())."\n" if ($verbose >2);
+                    print " Finished! ".(scalar localtime())."\n" if ($verbose >= 2);
                 }
             }
       }
@@ -266,7 +263,7 @@ sub prepareScript{
 
     my $string;          # temp string for perl-scripts, which will be called later
     chdir "$positionWD/seq/split" or die ("Cound not change directory to $positionWD/seq/split.\n");
-    my $splitDir=cwd();  # where splited contigs stored
+    my $splitDir=cwd();  # where split contigs stored
     
     # split fasta into subsets
     opendir(SPLITDIR, $splitDir) or die ("Could not open directory $splitDir.\n");
@@ -286,7 +283,7 @@ sub prepareScript{
 	$perlCmdString="perl $string --minsize=$minsize $genome --outputpath=$splitDir";
 	print "3 $perlCmdString ..." if ($verbose>=3);
 	system("$perlCmdString")==0 or die ("failed to execute: $!\n");
-	print "2 The splited fasta files have been placed under $splitDir\n" if ($verbose>=2);
+	print "2 The split fasta files have been placed under $splitDir\n" if ($verbose>=2);
     } else {
 	print "2 Using existing split genome FASTA files.\n" if ($verbose>=2);
     }
@@ -459,7 +456,7 @@ sub dirBuilder{
     die("The working directory not found! Please specify a valid one! \n") unless (-d $position);
     chdir "$position" or die ("Can not chdir to $position!\n");
 
-    # check the write permission of $positio before building of the main directory
+    # check the write permission of $position before building of the main directory
     if(!(-w $position)){
         print "Don\'t have write permission at $position!\n";
         die("Please use command \"chmod\" to change permission or specify another position.\n");

--- a/scripts/autoAugPred.pl
+++ b/scripts/autoAugPred.pl
@@ -46,7 +46,7 @@ my $clusterENVDefs = "export SGE_ROOT=/opt/sge";  # commands to define environme
 my $SGEqstatPath = "/opt/sge/bin/lx24-amd64/";    # path to executables on Sun Grid Engine (qsub, qstat)
 my $verbose=2;           # verbose level
 my $singleCPU=0;         # run sequentially on a single CPU
-my $nodeNum=20;          # node number in your cluster
+my $cpus=1;              # n is the number of CPUs to use (default: 1)
 my $user_config_path;    # AUGUSTUS_CONFIG_PATH if specified on the command line
 my $AUGUSTUS_CONFIG_PATH;# command line path, or environment variable, if not specified.
 my $perlCmdString;       # to store perl commands
@@ -78,6 +78,7 @@ autoAugPred.pl [OPTIONS] --genome=genome.fa --species=sname --hints=hintsfile
 options:
 --useexisting                  use and change the present config and parameter files if they exist for 'species'
 --singleCPU                    run sequentially on a single CPU instead of parallel jobs on a cluster
+--cpus=n                       n is the number of CPUs to use (default: 1), if cpus > 1 install Parallel::ForkManager for better performance
 --noninteractive               for Sun Grid Engine users, who have configurated an openssh key
                                with this option AUGUSTUS is executed automatically on the SGE cluster
 --workingdir=/path/to/wd/      in the working directory results and temporary files are stored.
@@ -105,9 +106,9 @@ GetOptions('workingdir=s' => \$positionWD,
 	   'continue'=> \$continue,
 	   'noninteractive!'=> \$noninteractive,
 	   'singleCPU!'=> \$singleCPU,
+	   'cpus=i' => \$cpus,
 	   'remote=s'=> \$cname,
 	   'verbose+' => \$verbose,
-	   'nodeNum=i' => \$nodeNum,
 	   'cname=s' => \$cname,
 	   'AUGUSTUS_CONFIG_PATH=s' => \$user_config_path,
 	   'useexisting!' => \$useexisting,
@@ -158,12 +159,48 @@ if($noninteractive){
 } else { # interactive
     if (@dopreds){
 	if ($singleCPU){
-	    print "1 running augustus jobs aug" . join(" aug", @dopreds) . " sequentially now\n" if ($verbose >= 1);
 	    chdir "$workDir/shells/";
-	    for (my $i=1; $i <= $splitN; $i++){
-		print "2 running aug$i\n" if ($verbose >= 2);
-		system ("./aug$i");
-	    }
+        if ($cpus<=1){
+            print "1 running augustus jobs aug" . join(" aug", @dopreds) . " sequentially now\n" if ($verbose >= 1);
+            for (my $i=1; $i <= $splitN; $i++){
+                print "2 running aug$i ".(scalar localtime())." ..." if ($verbose >= 2);
+                system ("./aug$i");
+                print " Finished! ".(scalar localtime())."\n" if ($verbose >2);
+            }
+        }
+        else {
+            print "1 running augustus jobs aug" . join(" aug", @dopreds) . " parallel now\n" if ($verbose >= 1);
+            my $got_ForkManager = 0;
+            eval { require Parallel::ForkManager };
+            unless ($@) {
+                Parallel::ForkManager->import();
+                $got_ForkManager = 1;
+            }
+            if ($got_ForkManager) {
+                my $pm = new Parallel::ForkManager( $cpus );
+                for (my $i=1; $i <= $splitN; $i++){
+                    my $pid = $pm->start and next; # fork and return the pid for the child:
+                    print "2 running aug$i parallel ".(scalar localtime())." ...\n" if ($verbose >= 2);
+                    system ("./aug$i");
+                    print " Finished aug$i! ".(scalar localtime())."\n" if ($verbose >2);
+                    $pm->finish; # terminate the child process
+                }
+                $pm->wait_all_children;
+            }
+            else {
+                my $i=1;
+                while ($i <= $splitN) {
+                    my $cmdString = "";
+                    for (my $step = 1; $step <= $cpus && $i <= $splitN; $i++, $step++){
+                        $cmdString .= "./aug$i & ";
+                    }
+                    $cmdString .= "wait ";
+                    print "2 running $cmdString ".(scalar localtime())." ..." if ($verbose >= 2);
+                    system ($cmdString);
+                    print " Finished! ".(scalar localtime())."\n" if ($verbose >2);
+                }
+            }
+      }
 	    print "1 done with augustus jobs\n" if ($verbose >= 1);
 	    continue_aug($shellDir, $utr, $hints);
 	} else {
@@ -243,7 +280,7 @@ sub prepareScript{
 	
 	# calculate minsize
 	my $minsize = `grep -v ">" $genome | wc -c`;
-	$minsize = int($minsize/$nodeNum)+1;
+	$minsize = int($minsize/$cpus)+1;
 	
 	print "2 splitting genome sequence into subsets of size >= $minsize bp\n" if ($verbose>=2);
 	$perlCmdString="perl $string --minsize=$minsize $genome --outputpath=$splitDir";

--- a/scripts/autoAugTrain.pl
+++ b/scripts/autoAugTrain.pl
@@ -161,7 +161,7 @@ sub train{
 	 "predictions/hints.E", "predictions/hints.UTR.E", "training/test", "training/utr")){
 	mkdir "$_" if (! -d $_)
     }
-    print "3 All necessary diretories have been created unter $workDir.\n" if ($verbose>=3);
+    print "3 All necessary directories have been created under $workDir.\n" if ($verbose>=3);
 
     if (!uptodate(["$trainingset"], ["$workDir/training/training.gb"])){
 	# detect format of the training set file and create training.gb
@@ -192,16 +192,16 @@ sub train{
 	    }
 	    # The GFF-file needs to be sorted such that for each gene or mRNA the exons are in increasing order 
 	    $cmdString="cat $trainingset | " . 'perl -pe \'s/\t\S*Parent=/\t/\' | sort -n -k 4 | sort -s -k 9 | sort -s -k 1,1 > training.gff';
-	    print "3 Running \"$cmdString\" ..." if ($verbose >2);
+	    print "3 Running \"$cmdString\" ".(scalar localtime())." ..." if ($verbose >2);
 	    system("$cmdString")==0 or die("failed to execute $!\n");
-	    print " Finished!\n" if ($verbose >2);
+	    print " Finished! ".(scalar localtime())."\n" if ($verbose >2);
 	    
 	    # converting trainingset to Genbank format
 	    print "3 converting $trainingset to Genbank format file ...\n" if ($verbose>=3);
 	    $perlCmdString = "perl $string $trainingset $genome $flanking_DNA training.gb";
 	    print "3 $perlCmdString\n" if ($verbose>2);
 	    system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString!\n");
-	    print "3 training.gb with genbank format has been created under $workDir/seq/training/.\n" if ($verbose>=3);
+	    print "3 training.gb with genbank format has been created under $workDir/training/.\n" if ($verbose>=3);
 	} elsif ($format eq "fasta-prot"){
 	    print "2 The input training set file has protein FASTA format. Converting to Genbank format...\n" if ($verbose>=2);
 	    scipio_conversion($trainingset);
@@ -248,7 +248,7 @@ sub train{
     }
     close TS;
     if($counter_gen == 0){
-	die("ERROR: training.gb is empty. Possible reasons:\n\ta) features in a provided training gene structure gff file were not compliant with the autoAug.pl pipeline (for instructions read at e.g. http://bioinf.uni-greifswald.de/webaugustus/help#structure\n\tb) Scipio failed to generate training gene structures\n\tThis will cause a crash of the autoAug.pl pipeline!\n");
+	die("ERROR: training.gb is empty. Possible reasons:\n\ta) features in a provided training gene structure file were not compliant with the autoAug.pl pipeline (for instructions read at e.g. http://bioinf.uni-greifswald.de/webaugustus/trainingtutorial#structure_file)\n\tb) If you provided a protein file: Scipio failed to generate training gene structures.\n\t   Please note that the number of proteins in the protein file needs to be sufficiently large to generate a minimum of 200 training gene structures for training AUGUSTUS.\n\t   At most one training gene structure is generated from a single protein, in some cases, not all proteins will align sufficiently well to generate a training gene structure, at all.\n\tThis will cause a crash of the autoAug.pl pipeline!\n");
     }
     my $ave=$counter_gen/$counter_seq;
     print "1 training.gb contains $counter_seq sequences and $counter_gen genes," if ($verbose>=1);
@@ -321,9 +321,9 @@ sub train{
 	
 	# first try with etraining
 	chdir "$workDir/training/" or die ("Can not change directory to $workDir/training.");
-	print "2 First try with etraining: etraining --species=$species training.gb.train >train.out ..." if ($verbose>=2);
+	print "2 First try with etraining: etraining --species=$species training.gb.train >train.out ".(scalar localtime())." ..." if ($verbose>=2);
 	system("etraining --species=$species training.gb.train 1>train.out 2>train.err")==0 or die("failed to execute: $!\n");
-	print " Finished!\n" if ($verbose>=2);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=2);
 	print "3 train.out and train.err have been made under $workDir/training.\n" if ($verbose>=3);
 	
 	# set "stopCodonExcludedFromCDS" to false and run etraining again if necessary
@@ -336,10 +336,10 @@ sub train{
 	    chdir "$configDir" or die ("Can not chdir to $configDir.\n");
 	    print "2 Setting value of \"stopCodonExcludedFromCDS\" in $paraName to \"false\"\n" if ($verbose>=2);
 	    setParInConfig($paraName, "stopCodonExcludedFromCDS", "false");
-	    print "3 Trying etraining again: etraining --species=$species training.gb.train >train.out ..." if ($verbose>=3);
+	    print "3 Trying etraining again: etraining --species=$species training.gb.train >train.out ".(scalar localtime())." ..." if ($verbose>=3);
 	    chdir "$workDir/training/" or die ("Can not change directory to $workDir/training.");
 	    system("etraining --species=$species training.gb.train 1>train.out 2>train.err")==0 or die("failed to execute: $!\n");
-	    print " Finished!\n" if ($verbose>=3);
+	    print " Finished! ".(scalar localtime())."\n" if ($verbose>=3);
 	    print "3 train.out and train.err have been made again under $workDir/training.\n" if ($verbose>=3);
 	}
 	
@@ -364,9 +364,9 @@ sub train{
 		  ["$workDir/training/test/augustus.1.out"])){
 	# first test with augustus
 	$cmdString = "augustus --species=$species $workDir/training/training.gb.test > $workDir/training/test/augustus.1.out";
-	print "2 First evaluation of parameters ...\n2 Executing \"$cmdString\" ..." if ($verbose>=2);
+	print "2 First evaluation of parameters ...\n2 Executing \"$cmdString\" ".(scalar localtime())." ..." if ($verbose>=2);
 	system("$cmdString")==0 or die("failed to execute: $cmdString!\n");
-	print " Finished!\n" if ($verbose>=2);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=2);
     }
     # caculate the accuracy
     my $aug_out="$workDir/training/test/augustus.1.out";
@@ -384,9 +384,9 @@ sub train{
 	    $cmdString="perl $string --rounds=$optrounds --species=$species $workDir/training/training.gb.train.test --onlytrain=$workDir/training/training.gb.onlytrain --metapars=$configDir/$metaName > optimize.out";
 	}
 	print "1 Optimizing meta parameters of AUGUSTUS\n" if ($verbose>=1);
-	print "2 Executing \"$cmdString\" ..." if ($verbose>=2);
+	print "2 Executing \"$cmdString\" ".(scalar localtime())." ..." if ($verbose>=2);
 	system("$cmdString")==0 or die("failed to execute: $cmdString!\n"); 
-	print " Finished!\n" if ($verbose>=2);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=2);
 	print "2 You can find all info about optimizing in $workDir/training/optimize.out!\n" if ($verbose>=2);
     } else {
 	print "1 Skipping optimization of AUGUSTUS metaparameters.\n" if ($verbose>=1);
@@ -396,9 +396,9 @@ sub train{
 	# train augustus again with optimized parameters
 	chdir "$workDir/training" or die ("Could not change directory to $workDir/training\n");
 	$cmdString = "etraining --species=$species training.gb.train 1>train.withoutCRF.out 2>train.withoutCRF.err";
-	print "2 Running $cmdString ..." if ($verbose>1);
+	print "2 Running $cmdString ".(scalar localtime())." ..." if ($verbose>1);
 	system("$cmdString")==0 or die("failed to execute: $cmdString!\n");
-	print " Finished!\n" if ($verbose>1);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>1);
 	
 	# another test on the holdout set, the output file augustus.2.out should have the better results
 	print "2 augustus --species=$species training.gb.test > ./test/augustus.2.withoutCRF.out\n" if ($verbose>1);
@@ -428,13 +428,14 @@ sub train{
 	print "1 Starting training with training as Conditional Random Field (CRF)\n" if ($verbose>=1);
 	chdir "$workDir/training" or die ("Could not change directory to $workDir/training\n");
 	$cmdString="etraining --species=$species training.gb.train --CRF=1 1>train.CRF.out 2>train.CRF.err";
-	print "1 Running $cmdString ..." if ($verbose>0);
+	print "1 Running $cmdString ".(scalar localtime())." ..." if ($verbose>0);
 	system("$cmdString")==0 or die("failed to execute: $cmdString!\n");
-	print " Finished!\n" if ($verbose>0);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>0);
 
 	# another test on the holdout set, the output file augustus.2.out should have the better results 
-	print "3 augustus --species=$species training.gb.test > ./test/augustus.2.CRF.out\n" if ($verbose>2); 
+	print "3 augustus --species=$species training.gb.test > ./test/augustus.2.CRF.out".(scalar localtime())." ..." if ($verbose>2); 
 	system("augustus --species=$species training.gb.test > ./test/augustus.2.CRF.out")==0 or die("failed to execute: $!\n");
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=2);
 
 	# calculate the accuracy again
 	$aug_out="$workDir/training/test/augustus.2.CRF.out";
@@ -526,9 +527,9 @@ sub trainWithUTR{
 	$string=find("makeUtrTrainingSet.pl");
 	print "3 Found script $string.\n" if ($verbose>=3);
 	$perlCmdString="perl $string stops.and.starts.gff $genome $estali utr";
-	print "2 Running command: $perlCmdString ..." if ($verbose>=2);
+	print "2 Running command: $perlCmdString ".(scalar localtime())." ..." if ($verbose>=2);
 	system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString\n");
-	print " Finished!\n" if ($verbose>=2);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=2);
     } else {
 	print "2 Reusing existing UTR training set.\n" if ($verbose>=2);
     }
@@ -536,9 +537,9 @@ sub trainWithUTR{
     # make gbrowse file utr.train.gbrowse
     if (!uptodate(["utr.gff"], ["$workDir/gbrowse/utr.train.gbrowse"])){
 	$string = find("utrgff2gbrowse.pl");
-	print "3 Running \"cat utr.gff | perl $string\"..." if ($verbose>=3);
+	print "3 Running \"cat utr.gff | perl $string\" ".(scalar localtime())." ..." if ($verbose>=3);
 	system("cat utr.gff | perl $string > utr.train.gbrowse")==0 or die ("failed to execute: $!\n");
-	print " Finished! Made file utr.train.gbrowse\n" if ($verbose>=3);
+	print " Finished! ".(scalar localtime())." Made file utr.train.gbrowse\n" if ($verbose>=3);
 	system("mv utr.train.gbrowse ../../gbrowse")==0 or die ("failed to execute: $!\n");
 	print "3 Moved utr.train.gbrowse to $workDir/gbrowse\n" if ($verbose>=3);
     }
@@ -588,9 +589,9 @@ sub trainWithUTR{
 	$string=find("gff2gbSmallDNA.pl");
 	print "3 Found script $string.\n" if ($verbose>=3);
 	$perlCmdString="perl $string genes.gtf ../../../seq/genome.fa $flanking_DNA bothutr.test.gb --good=bothutr.lst 1>gff2gbSmallDNA.stdout 2>gff2gbSmallDNA.stderr";
-	print "3 Running \"$perlCmdString\" ..." if ($verbose>=3);
+	print "3 Running \"$perlCmdString\" ".(scalar localtime())." ..." if ($verbose>=3);
 	system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString!\n");
-	print " Finished!\n" if ($verbose>=3);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=3);
     }
     ##################################################################################################
     # make a training set for optimization including m genes with both UTRs and n genes without UTRs #
@@ -629,13 +630,13 @@ sub trainWithUTR{
 	$string=find("randomSplit.pl");
 	print "3 Found script $string.\n" if ($verbose>=3);
 	$perlCmdString="perl $string bothutr.test.gb $m";
-	print "3 Running \"$perlCmdString\"..." if ($verbose>=3);
+	print "3 Running \"$perlCmdString\" ".(scalar localtime())." ..." if ($verbose>=3);
 	system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString!\n");
-	print " Finished!\n" if ($verbose>=3);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=3);
 	$perlCmdString="perl $string t.gb $n";
-	print "3 Running \"$perlCmdString\"..." if ($verbose>=3);
+	print "3 Running \"$perlCmdString\" ".(scalar localtime())." ..." if ($verbose>=3);
 	system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString!\n");
-	print " Finished!\n" if ($verbose>=3);
+	print " Finished! ".(scalar localtime())."\n" if ($verbose>=3);
 	my $delete;
 	open(GB, "t.gb.test") or die ("Can not open file t.gb.test!\n");
 	open(NOMRNA, "> t.nomrna.test.gb");
@@ -724,9 +725,9 @@ sub trainWithUTR{
 	$perlCmdString="perl $string --rounds=$optrounds --species=$species --trainOnlyUtr=1 --onlytrain=onlytrain.gb  --metapars=$configDir/$metaUtrName train.gb --UTR=on > optimize.utr.out";
 	print "1 Now optimizing meta parameters of AUGUSTUS for the UTR model." .
 	    " This will likely run for a long time..\n" if ($verbose>=1 && $optrounds > 0);
-	print "1 Running \"$perlCmdString\"..." if ($verbose>=1);
+	print "1 Running \"$perlCmdString\" ".(scalar localtime())." ..." if ($verbose>=1);
 	system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString!\n");
-	print " finished" if ($verbose>=3);
+	print " finished ".(scalar localtime())."\n" if ($verbose>=3);
 	system("cat train.gb ../training.gb.train > train.all.gb")==0 or die("failed to execute: $!\n");
     } else {
 	print "1 Skipping UTR parameter optimization. Already up to date.\n" if ($verbose>=1);
@@ -740,7 +741,7 @@ sub trainWithUTR{
 	system("etraining --species=$species --UTR=on train.all.gb --CRF=1 1>etrain.out 2>etrain.err")==0 or die("failed to execute: $!\n");
     }
 
-    print " Finished\n" if ($verbose>=2);
+    print " Finished ".(scalar localtime())."\n" if ($verbose>=2);
 }
 
 
@@ -807,18 +808,18 @@ sub scipio_conversion{
     check_fasta_headers($trainingset);
     chdir "$workDir/training/" or die("Error: could not change directory to $workDir/training/!\n");
     $cmdString = "scipio.pl $genome $trainingset > scipio.yaml 2> scipio.err"; 
-    print "3 $cmdString ..." if ($verbose>2); 
+    print "3 $cmdString ".(scalar localtime())." ..." if ($verbose>2);
     system("$cmdString")==0 or die("Program aborted. Possibly \"scipio\" is not installed or not in your PATH");
-    print "Finished.\n" if ($verbose>2);
-    $cmdString = "cat scipio.yaml | yaml2gff.1.4.pl --filterstatus=\"incomplete\"> scipio.gff 2> yaml2gff.err"; 
-    print "3 $cmdString ..." if ($verbose>2);
+    print "Finished. ".(scalar localtime())."\n" if ($verbose>2);
+    $cmdString = "cat scipio.yaml | yaml2gff.1.4.pl --filterstatus=\"incomplete\" > scipio.gff 2> yaml2gff.err"; 
+    print "3 $cmdString ".(scalar localtime())." ..." if ($verbose>2);
     system("$cmdString")==0 or die("Command aborted. Possibly \"scipio\" is not installed or not in your PATH\n");
-    print "Finished.\n" if ($verbose>2);
+    print "Finished. ".(scalar localtime())."\n" if ($verbose>2);
     my $pathstr = find("scipiogff2gff.pl");
     $cmdString = "$pathstr --in=scipio.gff --out=traingenes.gff";
-    print "3 $cmdString ..." if ($verbose>2);
+    print "3 $cmdString ".(scalar localtime())." ..." if ($verbose>2);
     system("$cmdString")==0 or die("Command aborted.\n");
-    print "Finished.\n" if ($verbose>2);
+    print "Finished. ".(scalar localtime())."\n" if ($verbose>2);
     # check whether gff file contains any entries                                                                                                                                     
     my $gffLines = 0;
     open(GFFforCounting, "<", "traingenes.gff") or die("Cannot open training gene structure gff file traingenes.gff!\n");
@@ -832,5 +833,5 @@ sub scipio_conversion{
     $perlCmdString="perl $pathstr traingenes.gff $genome $flanking_DNA training.gb";
     print "3 $perlCmdString\n" if ($verbose>2);
     system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString!\n");
-    print "3 training.gb with genbank format has been created under $workDir/seq/training/.\n" if ($verbose>2);      
+    print "3 training.gb with genbank format has been created under $workDir/training/.\n" if ($verbose>2);      
 }

--- a/scripts/autoAugTrain.pl
+++ b/scripts/autoAugTrain.pl
@@ -809,7 +809,19 @@ sub scipio_conversion{
     chdir "$workDir/training/" or die("Error: could not change directory to $workDir/training/!\n");
     $cmdString = "scipio.pl $genome $trainingset > scipio.yaml 2> scipio.err"; 
     print "3 $cmdString ".(scalar localtime())." ..." if ($verbose>2);
-    system("$cmdString")==0 or die("Program aborted. Possibly \"scipio\" is not installed or not in your PATH");
+    my $scipioStatus = system("$cmdString");
+    if ($scipioStatus != 0) {
+      if (-s "scipio.err") { # if non-empty
+        open( my $fh, '<', "scipio.err" ) or die("Can't open \"scipio.err\": $!");
+        print STDERR <$fh>;
+        print STDERR "\n";
+        close $fh;
+        die("Program aborted. Scipio failed.");
+      }
+      else {
+        die("Program aborted. Possibly \"scipio.pl\" is not installed or not in your PATH");
+      }
+    }
     print "Finished. ".(scalar localtime())."\n" if ($verbose>2);
     $cmdString = "cat scipio.yaml | yaml2gff.1.4.pl --filterstatus=\"incomplete\" > scipio.gff 2> yaml2gff.err"; 
     print "3 $cmdString ".(scalar localtime())." ..." if ($verbose>2);

--- a/scripts/autoAugTrain.pl
+++ b/scripts/autoAugTrain.pl
@@ -321,8 +321,9 @@ sub train{
 	
 	# first try with etraining
 	chdir "$workDir/training/" or die ("Can not change directory to $workDir/training.");
-	print "2 First try with etraining: etraining --species=$species training.gb.train >train.out ".(scalar localtime())." ..." if ($verbose>=2);
-	system("etraining --species=$species training.gb.train 1>train.out 2>train.err")==0 or die("failed to execute: $!\n");
+	my $etrainCmdString = "etraining --species=$species training.gb.train 1>train.out 2>train.err";
+	print "2 First try with etraining: $etrainCmdString ".(scalar localtime())." ..." if ($verbose>=2);
+	system("$etrainCmdString")==0 or die("failed to execute: $etrainCmdString\n");
 	print " Finished! ".(scalar localtime())."\n" if ($verbose>=2);
 	print "3 train.out and train.err have been made under $workDir/training.\n" if ($verbose>=3);
 	
@@ -336,9 +337,9 @@ sub train{
 	    chdir "$configDir" or die ("Can not chdir to $configDir.\n");
 	    print "2 Setting value of \"stopCodonExcludedFromCDS\" in $paraName to \"false\"\n" if ($verbose>=2);
 	    setParInConfig($paraName, "stopCodonExcludedFromCDS", "false");
-	    print "3 Trying etraining again: etraining --species=$species training.gb.train >train.out ".(scalar localtime())." ..." if ($verbose>=3);
+	    print "3 Trying etraining again: $etrainCmdString ".(scalar localtime())." ..." if ($verbose>=3);
 	    chdir "$workDir/training/" or die ("Can not change directory to $workDir/training.");
-	    system("etraining --species=$species training.gb.train 1>train.out 2>train.err")==0 or die("failed to execute: $!\n");
+	    system("$etrainCmdString")==0 or die("failed to execute: $etrainCmdString\n");
 	    print " Finished! ".(scalar localtime())."\n" if ($verbose>=3);
 	    print "3 train.out and train.err have been made again under $workDir/training.\n" if ($verbose>=3);
 	}
@@ -527,9 +528,9 @@ sub trainWithUTR{
 	$string=find("makeUtrTrainingSet.pl");
 	print "3 Found script $string.\n" if ($verbose>=3);
 	$perlCmdString="perl $string stops.and.starts.gff $genome $estali utr";
-	print "2 Running command: $perlCmdString ".(scalar localtime())." ..." if ($verbose>=2);
+	print "2 Running command: $perlCmdString ".(scalar localtime())." ...\n" if ($verbose>=2);
 	system("$perlCmdString")==0 or die ("failed to execute: $perlCmdString\n");
-	print " Finished! ".(scalar localtime())."\n" if ($verbose>=2);
+	print "2 Finished! ".(scalar localtime())."\n" if ($verbose>=2);
     } else {
 	print "2 Reusing existing UTR training set.\n" if ($verbose>=2);
     }

--- a/scripts/gff2gbSmallDNA.pl
+++ b/scripts/gff2gbSmallDNA.pl
@@ -175,6 +175,13 @@ sub insertExon {
     }
 }
 
+# escape characters according GFF3 Format restrictions for Column 1: "seqid"  
+# see http://gmod.org/wiki/GFF3
+sub escape_seqid {
+    my ($seqID) = @_;
+    $seqID =~ s/([^a-zA-Z0-9\.:\^\*\$@!\+_\?\-\|])/sprintf("%%%02X",ord($1))/ge;
+    return $seqID;
+}
 
 #
 # Now write the data
@@ -193,20 +200,36 @@ while(<FASTA>) {
     
     $length = length $seq;
     $annotation = $annos{$seqname};
-    my $shortseqname = $seqname;
-    $shortseqname =~ s/\s.*//;
-
-    if (!defined($annotation) && defined($annos{$shortseqname})){
-	$seqnameerrcount++;
-	if ($seqnameerrcount <= 10){
-	    print STDERR "Sequence $seqname has no annotation but $shortseqname has. ";
-	    print STDERR "Assuming that space truncates name.\n";
-	}
-	if ($seqnameerrcount == 10){
-	    print STDERR "Supressing this error message from now on.\n";
-	}
-	$seqname = $shortseqname;
-	$annotation = $annos{$shortseqname};
+    my $annotatedseqname = $seqname;
+    
+    if (!defined($annotation)) {
+        my $shortseqname = $seqname =~ s/\s.*//r;
+        $annotatedseqname = $shortseqname;
+        $annotation = $annos{$annotatedseqname}; # try the short sequence name (split at first whitespace)
+        my $usedshortseqname = defined($annotation);
+        
+        if (!defined($annotation)) { # check if seq id in gff-file contains escaped characters
+            $annotatedseqname = escape_seqid($seqname);
+            $annotation = $annos{$annotatedseqname}; # try the escaped sequence name (as demanded by GFF3 format)
+            
+            if (!defined($annotation)) {
+                $annotatedseqname = escape_seqid($shortseqname);
+                $annotation = $annos{$annotatedseqname}; # try the escaped short sequence name
+                $usedshortseqname = defined($annotation);
+            }
+        }
+        
+        if ($usedshortseqname) {
+            $seqnameerrcount++;
+            if ($seqnameerrcount <= 10) {
+                print STDERR "Sequence $seqname has no annotation but $shortseqname has. ";
+                print STDERR "Assuming that space truncates name.\n";
+                if ($seqnameerrcount == 10) {
+                    print STDERR "Supressing this error message from now on.\n";
+                }
+            }
+            $seqname = $shortseqname;
+        }
     }
     # For each UTR annotation check whether there is a CDS annoation with the same name and matching boundaries.
     # If yes, make an mRNA from the UTR and discard the UTR annotation.
@@ -276,7 +299,7 @@ while(<FASTA>) {
 	}
     }
 
-    my @nr_sort_fkeyarray = nrsort(values %{$annos{$seqname}});
+    my @nr_sort_fkeyarray = nrsort(values %{$annos{$annotatedseqname}});
 
     # extract only the cds annotations
     my @cdsfkeys = ();

--- a/scripts/helpMod.pm
+++ b/scripts/helpMod.pm
@@ -195,7 +195,7 @@ sub check_fasta_headers {
             $orSign++;
         }
         if (!$someThingWrongWithHeader && $line =~ /[^>a-zA-Z0-9]/) {
-            print "WARNING: Fasta headers inf file $fastaFile seem to contain non-letter and non-number characters. That means they may contain some kind of special character. $stdStr\n";
+            print "WARNING: Fasta headers in file $fastaFile seem to contain non-letter and non-number characters. That means they may contain some kind of special character. $stdStr\n";
             $someThingWrongWithHeader++;
         }
         if ($spaces && $orSign && $someThingWrongWithHeader) {

--- a/scripts/optimize_augustus.pl
+++ b/scripts/optimize_augustus.pl
@@ -65,7 +65,7 @@ sub got_interrupt_signal {
     if ( !$cgp ) {
         if ( $cmdpars{'opt_trans_matrix'} ne '' ) {
             if ( -s $cmdpars{'opt_trans_matrix'} . ".curopt" ) {
-                system(
+                systemordie(
                     "cp $cmdpars{'opt_trans_matrix'}.curopt $cmdpars{'opt_trans_matrix'}"
                 );
                 print STDERR
@@ -391,7 +391,7 @@ if ( !$got_ForkManager && $cmdpars{'cpus'} > 1 ) {
 ##############################################################
 
 my $optdir = "tmp_opt_$cmdpars{'species'}";
-system("rm -rf $optdir;mkdir $optdir");
+systemordie("rm -rf $optdir;mkdir $optdir");
 opendir( TMPDIR, $optdir ) or die("Could not open $optdir");
 
 # only needed in cgp
@@ -473,14 +473,14 @@ if ( !$cgp ) {
         for ( my $k = 1; $k <= $cmdpars{"kfold"}; $k++ ) {
 
             # make the temporary training and testing files
-            system("rm -f $optdir/curtrain-$k");
+            systemordie("rm -f $optdir/curtrain-$k");
             for ( my $m = 1; $m <= $cmdpars{"kfold"}; $m++ ) {
                 if ( $m != $k ) {
-                    system("cat $optdir/bucket$m.gb >> $optdir/curtrain-$k");
+                    systemordie("cat $optdir/bucket$m.gb >> $optdir/curtrain-$k");
                 }
             }
             if ( $cmdpars{'onlytrain'} ne '' ) {
-                system("cat $cmdpars{'onlytrain'} >> $optdir/curtrain-$k");
+                systemordie("cat $cmdpars{'onlytrain'} >> $optdir/curtrain-$k");
             }
         }
     }
@@ -658,7 +658,7 @@ if ( $cmdpars{'opt_trans_matrix'} eq '' ) {
     }
     if ( $y < 20 ) {
         close(ORIG);
-        system("cp $species_cfg_filename $species_cfg_filename.orig$y");
+        systemordie("cp $species_cfg_filename $species_cfg_filename.orig$y");
     }
     else {
         die("Too many $species_cfg_filename.orig copies. Please delete some."
@@ -712,7 +712,7 @@ else {
     }
     if ( $y < 40 ) {
         close(ORIG);
-        system(
+        systemordie(
             "cp $cmdpars{'opt_trans_matrix'} $cmdpars{'opt_trans_matrix'}.orig$y"
         );
     }
@@ -984,7 +984,7 @@ if ( $cmdpars{'noTrainPars'} eq '' ) {
 
     # delete the temporary *pbl files
     for ( my $k = 1; $k <= $cmdpars{"kfold"}; $k++ ) {
-        system(
+        systemordie(
             "rm -f $speciesdir/exon-tmp$k.pbl $speciesdir/intron-tmp$k.pbl $speciesdir/igenic-tmp$k.pbl $speciesdir/utr-tmp$k.pbl"
         );
     }
@@ -994,16 +994,16 @@ if ( $cmdpars{'noTrainPars'} eq '' ) {
         for ( my $k = 1; $k <= $cmdpars{"kfold"}; $k++ ) {
 
             # delete the temporary training files
-            system("rm -f $optdir/curtrain-$k $optdir/predictions-$k.txt");
+            systemordie("rm -f $optdir/curtrain-$k $optdir/predictions-$k.txt");
         }
     }
     print "Making final training with the optimized parameters.\n";
 
     # make the joint training file (train.gb and onlytrain.gb)
-    system("rm -f $optdir/curtrain $optdir/curtest");
-    system("cp $cmdpars{'train.gb'} $optdir/curtrain");
+    systemordie("rm -f $optdir/curtrain $optdir/curtest");
+    systemordie("cp $cmdpars{'train.gb'} $optdir/curtrain");
     if ( $cmdpars{'onlytrain'} ne '' ) {
-        system("cat $cmdpars{'onlytrain'} >> $optdir/curtrain");
+        systemordie("cat $cmdpars{'onlytrain'} >> $optdir/curtrain");
     }
     my $cmd = "";
     if ( $cmdpars{'nice'} == 1 ) {
@@ -1012,8 +1012,8 @@ if ( $cmdpars{'noTrainPars'} eq '' ) {
     $cmd
         .= "etraining --species=$cmdpars{'species'} --AUGUSTUS_CONFIG_PATH=$configdir $be_silent $optdir/curtrain $pars $modelrestrict";
     print "$cmd\n";
-    system($cmd);
-    system("rm -f $optdir/curtrain");
+    systemordie($cmd);
+    systemordie("rm -f $optdir/curtrain");
 }
 
 #######################################################################################
@@ -1021,7 +1021,7 @@ if ( $cmdpars{'noTrainPars'} eq '' ) {
 #######################################################################################
 
 if($cmdpars{'cleanup'}==1){
-  system ("rm -rf $optdir");
+  systemordie ("rm -rf $optdir");
 }
 
 
@@ -1070,15 +1070,15 @@ sub evalsnsp {
             for ( my $k = 1; $k <= $cmdpars{"kfold"}; $k++ ) {
 
                 # make the temporary training and testing files
-                system("rm -f $optdir/curtrain $optdir/curtest");
-                system("cp $optdir/bucket$k.gb $optdir/curtest");
+                systemordie("rm -f $optdir/curtrain $optdir/curtest");
+                systemordie("cp $optdir/bucket$k.gb $optdir/curtest");
                 for ( my $m = 1; $m <= $cmdpars{"kfold"}; $m++ ) {
                     if ( $m != $k ) {
-                        system("cat $optdir/bucket$m.gb >> $optdir/curtrain");
+                        systemordie("cat $optdir/bucket$m.gb >> $optdir/curtrain");
                     }
                 }
                 if ( $cmdpars{'onlytrain'} ne '' ) {
-                    system("cat $cmdpars{'onlytrain'} >> $optdir/curtrain");
+                    systemordie("cat $cmdpars{'onlytrain'} >> $optdir/curtrain");
                 }
                 if ( $cmdpars{'noTrainPars'} eq '' )
                 { # no need to retrain if the trans matrix is optimized or this option is otherwise explicitly set.
@@ -1088,7 +1088,7 @@ sub evalsnsp {
                     }
                     $cmd
                         .= "$cmdpars{'aug_exec_dir'}etraining --species=$cmdpars{'species'} --AUGUSTUS_CONFIG_PATH=$configdir $argument $pars $be_silent $modelrestrict $optdir/curtrain";
-                    system($cmd);
+                    systemordie($cmd);
                 }
                 my $cmd = "";
                 if ( $cmdpars{'nice'} == 1 ) {
@@ -1096,7 +1096,7 @@ sub evalsnsp {
                 }
                 $cmd
                     .= "$cmdpars{'aug_exec_dir'}augustus --species=$cmdpars{'species'} --AUGUSTUS_CONFIG_PATH=$configdir $argument $pars $optdir/curtest > $optdir/predictions.txt";
-                system($cmd);
+                systemordie($cmd);
 
                 open( PRED, "<$optdir/predictions.txt" );
                 while (<PRED>) {
@@ -1171,7 +1171,7 @@ sub evalsnsp {
                     $cmd
                         .= "$cmdpars{'aug_exec_dir'}etraining --species=$cmdpars{'species'} --AUGUSTUS_CONFIG_PATH=$configdir $argument $pars "
                         . "$be_silent $modelrestrict $pbloutfiles $optdir/curtrain-$k";
-                    system($cmd);
+                    systemordie($cmd);
 
                     #   unlink $optdir/curtrain-$k;
                 }
@@ -1185,7 +1185,7 @@ sub evalsnsp {
                 }
                 $cmd
                     .= "$cmdpars{'aug_exec_dir'}augustus --species=$cmdpars{'species'} --AUGUSTUS_CONFIG_PATH=$configdir $argument $pars $pblinfiles $optdir/bucket$k.gb > $optdir/predictions-$k.txt";
-                system($cmd);
+                systemordie($cmd);
                 print "$k ";
 
                 $pm->finish;    # terminate the child process
@@ -1257,14 +1257,14 @@ sub evalsnsp {
             my $pid = $pm->start and next;
 
             # this part is done in parallel by the child process
-            system("rm -rf $optdir/pred$k; mkdir $optdir/pred$k");
+            systemordie("rm -rf $optdir/pred$k; mkdir $optdir/pred$k");
             my $cmd = "";
             if ( $cmdpars{'nice'} == 1 ) {
                 $cmd .= "nice ";
             }
             $cmd
                 .= "$cmdpars{'aug_exec_dir'}augustus --species=$cmdpars{'species'} --AUGUSTUS_CONFIG_PATH=$configdir $argument $pars --alnfile=$optdir/splitMaf/$k.maf --/CompPred/outdir=$optdir/pred$k >$optdir/pred$k/aug.out";
-            system($cmd);
+            systemordie($cmd);
             print "$k ";
             $pm->finish;    # terminate the child process
         }
@@ -2040,7 +2040,7 @@ sub splitMaf {
 
     # directory of alignment chunks
     my $mafDir = "$optdir/splitMaf";
-    system("rm -rf $mafDir; mkdir $mafDir");
+    systemordie("rm -rf $mafDir; mkdir $mafDir");
 
     open( MAF, <$cmdpars{"alnfile"}> )
         or die("Could not open $cmdpars{'alnfile'} for reading: $!");
@@ -2050,7 +2050,7 @@ sub splitMaf {
 
     if ( $cmdpars{'cpus'} <= 1 )
     {   # in the serial case just make a temporary copy of the whole alignment
-        system("cp $cmdpars{'alnfile'} $mafDir/$cmdpars{'kfold'}.maf");
+        systemordie("cp $cmdpars{'alnfile'} $mafDir/$cmdpars{'kfold'}.maf");
     }
     else {
 
@@ -2120,7 +2120,7 @@ sub evalCGP {
 
 # temporary directory that contains the prediction and the annotation split by seq
     my $gffDir = "$optdir/tempGFF";
-    system("rm -rf $gffDir; mkdir $gffDir");
+    systemordie("rm -rf $gffDir; mkdir $gffDir");
 
     my @intervals = ();    # hash of genomic intervals
     my %seqlist   = ();    # hash of sequences (only keys, no values)
@@ -2203,25 +2203,25 @@ sub evalCGP {
 
 # filter prediction for duplicates and merge genes (uses external tool 'joingenes')
     if ($joingenes) {
-        system("mv $optdir/pred.gtf $optdir/pred.unfiltered.gtf");
+        systemordie("mv $optdir/pred.gtf $optdir/pred.unfiltered.gtf");
         my $cmd = "";
         if ( $cmdpars{'nice'} == 1 ) {
             $cmd .= "nice ";
         }
         $cmd
             .= "$cmdpars{'jg_exec_dir'}joingenes -g $optdir/pred.unfiltered.gtf -o $optdir/pred.gtf";
-        system($cmd);
+        systemordie($cmd);
     }
 
 # split annotation and prediction file by seqs and prepare
 # list files that contain the directories of the GTF files being compared (required by eval)
-    system("rm -f $optdir/annotation_list");
-    system("rm -f $optdir/prediction_list");
+    systemordie("rm -f $optdir/annotation_list");
+    systemordie("rm -f $optdir/prediction_list");
     foreach my $seq ( keys %seqlist ) {
-        system("echo '$gffDir/$seq.anno.gtf' >> $optdir/annotation_list");
-        system("echo '$gffDir/$seq.pred.gtf' >> $optdir/prediction_list");
-        system("grep \"^$seq\\b\" $optdir/pred.gtf > $gffDir/$seq.pred.gtf");
-        system("grep \"^$seq\\b\" $optdir/anno.gtf > $gffDir/$seq.anno.gtf");
+        systemordie("echo '$gffDir/$seq.anno.gtf' >> $optdir/annotation_list");
+        systemordie("echo '$gffDir/$seq.pred.gtf' >> $optdir/prediction_list");
+        systemordie("grep \"^$seq\\b\" $optdir/pred.gtf > $gffDir/$seq.pred.gtf");
+        systemordie("grep \"^$seq\\b\" $optdir/anno.gtf > $gffDir/$seq.anno.gtf");
     }
 
     # call evaluate_gtf
@@ -2268,4 +2268,9 @@ sub evalCGP {
         );
     }
     return ( $cbsn, $cbsp, $cesn, $cesp, $cgsn, $cgsp, -1, -1 );
+}
+
+sub systemordie {
+    my $cmdString = shift;
+    system($cmdString)==0 or die ("failed to execute: $cmdString\n");
 }

--- a/scripts/yaml2gff.1.4.pl
+++ b/scripts/yaml2gff.1.4.pl
@@ -71,11 +71,22 @@ sub nu_to_aa {
     return ($arg-$residue)/3;
 }
 
-sub escape {
+# escape according to GFF3 Format restrictions for Column 1: "seqid"  
+# see http://gmod.org/wiki/GFF3
+sub escape_seqid {
     foreach(@_) {
-	s/([^a-zA-Z0-9.:^*$@!+_?-|])/sprintf("%%%02X",ord($1))/ge;
+        s/([^a-zA-Z0-9\.:\^\*\$@!\+_\?\-\|])/sprintf("%%%02X",ord($1))/ge;
     }
 }
+
+# escape according to GFF3 Format restrictions for Column 9: "attributes"   
+# see http://gmod.org/wiki/GFF3
+sub escape_attribute {
+    foreach(@_) {
+        s/([\t,=;])/sprintf("%%%02X",ord($1))/ge;
+    }
+}
+
 
 sub with_number {
     my ($n, $s, $alt) = @_;
@@ -116,7 +127,7 @@ sub get_gapstr {
 sub output {
     my ($queryname, $hitlist) = @_;
     next if ($filterStatus && $hitlist->[0]{"status"} eq $filterStatus);
-    escape($queryname);
+    escape_attribute($queryname);
     print "##query\t$queryname 1 ".$hitlist->[0]{"${QPFX}_len"};
     my ($pstart, $pend, $plen) = ($hitlist->[0]{"${QPFX}_start"}, @{$hitlist->[-1]}{"${QPFX}_end", "${QPFX}_len"});
     my $prev_end = 0;
@@ -130,7 +141,7 @@ sub output {
 		     "gaps", "stopcodon", "status", "${QPFX}_seq",
 		     "${QPFX}_start", "${QPFX}_end", "${QPFX}_len"};
 	$targetname =~ s/\s.*//;
-	escape($targetname);
+	escape_seqid($targetname);
 	$gapcount = 0 unless (defined $gapcount);
 	$stopcodon = "" unless (defined $stopcodon);
 	


### PR DESCRIPTION
- introduce parameter --cpu and run commands in parallel wherever possible
- introduce parameter --webaugustus for error messages adapted to webservice
- improve log messages (mostly print timestamps)
- print scipio errormessages to STDERR - so a user can see them
- fix bug when user submit coding sequences instead of ESTs
- fix gff escape sequence names bug
- introduce parameter --augustusoptions to autoAugPred.pl to call augustus with all available parameters
- introduce parameter --predictionresultsdir to autoAugPred.pl to specify were the prediction results are stored