### PR TITLE
Add man page for pp_simScore

### DIFF
--- a/mansrc/pp_simScore.1
+++ b/mansrc/pp_simScore.1
@@ -1,0 +1,250 @@
+'\" t
+.\"     Title: pp_simscore
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "PP_SIMSCORE" "1" "" "\ \&" "\ \&"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+pp_simscore \- print similarity and alignments between protein profile and sequence on the standard output
+.SH "SYNOPSIS"
+.sp
+\fBpp_simScore\fP [OPTIONS] \-\-fasta=\fIprotein\-sequence\-file\fP \-\-prfl=\fIprotein\-profile\-file\fP
+.SH "DESCRIPTION"
+.sp
+Algorithm for calculating the similarity score and the optimal alignments between a protein profile and a protein sequence.
+The algorithm can optional take intron positions into account. Print to standard output.
+.SH "OPTIONS"
+.SS "Mandatory options"
+.sp
+\fB\-f\fP, \fB\-\-fasta\fP=\fIfile\fP
+.RS 4
+Protein sequence file in FASTA format.
+.RE
+.sp
+\fB\-p\fP, \fB\-\-prfl\fP= \fIfile\fP
+.RS 4
+Protein profile file.
+.RE
+.SS "Additional options"
+.sp
+\fB\-g\fP, \fB\-\-gap_inter\fP=\fIfloat\fP
+.RS 4
+Gap costs for an alignment column that is a gap in an inter\-block section. Default Value: \-5.0
+.RE
+.sp
+\fB\-b\fP, \fB\-\-gap_intra\fP=\fIfloat\fP
+.RS 4
+Gap costs for an alignment column that is a gap in a block. Default Value: \-50.0
+.RE
+.sp
+\fB\-r\fP, \fB\-\-gap_intron\fP=\fIfloat\fP
+.RS 4
+Gap costs for an gap in intron positions. Default Value: \-5.0
+.RE
+.sp
+\fB\-e\fP, \fB\-\-epsilon_intron\fP=\fIfloat\fP
+.RS 4
+Pseudocount parameter epsilon1, the pseudocount is added to a relative intron frequency v/w with (v+epsilon1)/(w+epsilon1+epsilon2). Default Value: 0.0000001
+.RE
+.sp
+\fB\-n\fP, \fB\-\-epsilon_noIntron\fP=\fIfloat\fP
+.RS 4
+Pseudocount parameter epsilon2, the pseudocount is added to a relative intron frequency v/w with (v+epsilon1)/(w+epsilon1+epsilon2). Default Value: 0.1
+.RE
+.sp
+\fB\-i\fP, \fB\-\-intron_weight_intra\fP=\fIfloat\fP
+.RS 4
+Value that is added to an intron score for a match of intron positions in a block. Default Value: 5.0
+.RE
+.sp
+\fB\-t\fP, \fB\-\-intron_weight_inter\fP=\fIfloat\fP
+.RS 4
+Value that is added to an intron score for a match of intron positions in an inter\-block. Default Value: 5.0
+.RE
+.sp
+\fB\-a\fP, \fB\-\-alignment\fP=\fInumber\fP
+.RS 4
+Number of optimal alignments that are computed. Default Value: 1
+.RE
+.sp
+\fB\-o\fP, \fB\-\-out\fP=\fIformat\fP
+.RS 4
+.sp
+Denotes the output format, the following output options are implemented:
+.RS 4
+.sp
+\fBscore\fP
+.RS 4
+output is the similarity score
+.RE
+.sp
+\fBmatrix\fP
+.RS 4
+output are similarity matrix and similarity score
+.RE
+.sp
+\fBalignment\fP
+.RS 4
+output are the computed alignments as
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Alignment representation of P as symbols of
+{AminoAcid, gap symbol or number of amino acids in inter\-block}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Alignment representation of argmax of B as symbols of
+{argmax AminoAcid for aligned block column, gap symbol or inter\-block length}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Frequency of amino acid of P in aligned block column of B, if alignment type is a match
+.RE
+.RE
+.sp
+\fBmatrix+alignment\fP
+.RS 4
+output are similarity matrix,
+similarity score and the computed
+alignments in the format described above
+.RE
+.sp
+\fBdb\fP
+.RS 4
+output are the computed alignment
+as list of alignment frames,
+an element of the list consists of:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+starting position of the first amino acid of the protein sequence that is included in the alignment frame
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+block number in which the alignment frame is located
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+index of the first block column that is included in the alignment frame
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+length of the frame (number of alignment columns)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+alignment type: \(aqm\(aq, \(aqs\(aq. \(aqp\(aq or \(aq\-\(aq
+.RE
+.RE
+.sp
+\fBbp\fP
+.RS 4
+output is a list of translations from the index of a block
+to the number of the block in the .prfl file
+.RE
+.sp
+\fBconsents\fP
+.RS 4
+output is the average of the argmax
+of the block columns for the complete profile
+.RE
+.sp
+\fBinterblock\fP
+.RS 4
+output is a list of all inter\-block distance intervals
+.RE
+.RE
+.sp
+
+.RS 4
+Default Value: \fBscore\fP
+.RE
+.RE
+.sp
+\fB\-h\fP, \fB\-\-help\fP
+.RS 4
+Produce help message.
+.RE
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+pp_simScore \-\-fasta=EDW03868.1.fa \-\-prfl=EOG09150290.prfl \-\-out=alignment
+.fi
+.if n \{\
+.RE
+.\}
+.SH "AUTHORS"
+.sp
+AUGUSTUS was written by M. Stanke, O. Keller, S. König, L. Gerischer, L. Romoth and L.Gabriel.

--- a/mansrc/pp_simScore.1.adoc
+++ b/mansrc/pp_simScore.1.adoc
@@ -1,0 +1,90 @@
+# pp_simScore(1)
+
+## NAME
+
+pp_simScore - print similarity and alignments between protein profile and sequence on the standard output
+
+## SYNOPSIS
+
+*pp_simScore* [OPTIONS] --fasta=_protein-sequence-file_ --prfl=_protein-profile-file_
+
+## DESCRIPTION
+
+Algorithm for calculating the similarity score and the optimal alignments between a protein profile and a protein sequence. 
+The algorithm can optional take intron positions into account. Print to standard output.
+
+## OPTIONS
+
+### Mandatory options
+    
+*-f*, *--fasta*=_file_::
+  Protein sequence file in FASTA format.
+
+*-p*, *--prfl*= _file_::
+  Protein profile file.
+
+### Additional options
+
+*-g*, *--gap_inter*=_float_::
+  Gap costs for an alignment column that is a gap in an inter-block section. Default Value: -5.0
+
+*-b*, *--gap_intra*=_float_::
+  Gap costs for an alignment column that is a gap in a block. Default Value: -50.0
+
+*-r*, *--gap_intron*=_float_::
+  Gap costs for an gap in intron positions. Default Value: -5.0
+
+*-e*, *--epsilon_intron*=_float_::
+  Pseudocount parameter epsilon1, the pseudocount is added to a relative intron frequency v/w with (v+epsilon1)/(w+epsilon1+epsilon2). Default Value: 0.0000001
+
+*-n*, *--epsilon_noIntron*=_float_::
+  Pseudocount parameter epsilon2, the pseudocount is added to a relative intron frequency v/w with (v+epsilon1)/(w+epsilon1+epsilon2). Default Value: 0.1
+
+*-i*, *--intron_weight_intra*=_float_::
+  Value that is added to an intron score for a match of intron positions in a block. Default Value: 5.0
+
+*-t*, *--intron_weight_inter*=_float_::
+  Value that is added to an intron score for a match of intron positions in an inter-block. Default Value: 5.0
+
+*-a*, *--alignment*=_number_::
+  Number of optimal alignments that are computed. Default Value: 1
+
+*-o*, *--out*=_format_::
+ Denotes the output format, the following output options are implemented: :::
+  *score*     :::: output is the similarity score
+  *matrix*    :::: output are similarity matrix and similarity score
+  *alignment* :::: output are the computed alignments as 
+   * Alignment representation of P as symbols of 
+     {AminoAcid, gap symbol or number of amino acids in inter-block}
+   * Alignment representation of argmax of B as symbols of 
+      {argmax AminoAcid for aligned block column, gap symbol or inter-block length}
+   * Frequency of amino acid of P in aligned block column of B, if alignment type is a match 
+  *matrix+alignment* :::: output are similarity matrix,
+                          similarity score and the computed
+                          alignments in the format described above
+  *db*                :::: output are the computed alignment
+                           as list of alignment frames,
+                           an element of the list consists of:
+     * starting position of the first amino acid of the protein sequence that is included in the alignment frame
+     * block number in which the alignment frame is located
+     * index of the first block column that is included in the alignment frame
+     * length of the frame (number of alignment columns)
+     * alignment type: 'm', 's'. 'p' or '-'
+  *bp*               :::: output is a list of translations from the index of a block
+                          to the number of the block in the .prfl file
+  *consents*         :::: output is the average of the argmax
+                          of the block columns for the complete profile
+  *interblock*       :::: output is a list of all inter-block distance intervals
+
+  ::: Default Value: *score*
+
+*-h*, *--help*::
+   Produce help message.
+
+## EXAMPLE
+
+  pp_simScore --fasta=EDW03868.1.fa --prfl=EOG09150290.prfl --out=alignment
+
+## AUTHORS
+
+AUGUSTUS was written by M. Stanke, O. Keller, S. König, L. Gerischer, L. Romoth and L.Gabriel.

--- a/src/pp_simscore.cc
+++ b/src/pp_simscore.cc
@@ -66,7 +66,7 @@ using namespace SS;
             +  itoa(n) + " < 0)");
     }
 
-    //add a Row to the simialrity matrix
+    //add a Row to the similarity matrix
     void SimilarityMatrix::addRow (int l, int p) {
         Row r(l,p);
         matrix.push_back(r);
@@ -157,7 +157,7 @@ using namespace SS;
         return num_prev_introns[end]-num_prev_introns[start];
     }
 
-    //intiates parameter
+    //initiates parameter
     SimilarityScore::SimilarityScore (double g, double b, double g_i, double iw1,\
         double iw2, double e_i, double e_n) {
         gap_cost_inter = g;
@@ -219,7 +219,7 @@ using namespace SS;
         //col holds the current block column that is represented by the
         //current row of the similarity matrix
         PP::Column col;
-        //d holds the inter-block distnace interval that is located before
+        //d holds the inter-block distance interval that is located before
         //the current block of the profile
         PP::DistanceType d;
 
@@ -488,7 +488,7 @@ using namespace SS;
     //after which an intron occurs or -1 if there no intron is in P located
     double SimilarityScore::intraBlock_iscore (int k, int s, int f, int intron_frame) {
         double prfl_freq;
-        //relative frequency of introns in B at this intron positon
+        //relative frequency of introns in B at this intron position
         prfl_freq = prfl->getIntronIntraFreq(k, s, f);
         if (intron_frame == f)
             return intron_weight_intra * (log10((prfl_freq + epsi_intron)/ \
@@ -541,7 +541,7 @@ using namespace SS;
             new_bt.col_posStart = new_bt.col_count;
             new_bt.align_element.length = 0;
 
-            //initial case for the recursion: start a new alignemnt for every
+            //initial case for the recursion: start a new alignment for every
             //predecessor of the final similarity score
             k_max = (number_Alignments < S[new_bt.i][new_bt.j].prev.size()) ? \
                 number_Alignments : S[new_bt.i][new_bt.j].prev.size();
@@ -618,7 +618,7 @@ using namespace SS;
                             }
                         }
                         //create new alignments, if there is more than one predecessor
-                        //in the similarty matrix
+                        //in the similarity matrix
                         else if (k > 0)
                             bt.push_back(new_bt);
                         //update current alignment
@@ -642,7 +642,7 @@ using namespace SS;
         }
     }
 
-    //translation from block indices of data strucure to block position in file
+    //translation from block indices of data structure to block position in file
     void SimilarityScore::printBlockPos () {
         for (int i = 0; i < prfl->blockCount(); i++) {
                 cout << i << '\t' << prfl[0][i].blockNumbInFile << endl;
@@ -815,7 +815,7 @@ USAGE: ./pp_simScore [OPTIONS] --fasta protein_sequence_file --prfl protein_prof
                                 default setting: -5\n\n \
     --gap_intra:                gap costs for an alignment column that is a gap in a block \n\
                                 default setting: -50\n\n\
-    --gap_intra:                gap costs for an gap in intron positions\n\
+    --gap_intron:               gap costs for a gap in intron positions\n\
                                 default setting: -5\n\n\
     --epsilon_intron:           pseudocount parameter epsilon1, the pseudocount is added to a relative intron frequency v/w with (v+epsilon1)/(w+epsilon1+epsilon2)\n\
                                 default setting: 0.0000001\n\n\
@@ -826,14 +826,14 @@ USAGE: ./pp_simScore [OPTIONS] --fasta protein_sequence_file --prfl protein_prof
     --intron_weight_inter:      value that is added to an intron score for a match of intron positions in an inter-block\n\
                                 default setting: 5\n\n\
     --alignment:                number of optimal alignments that are computed\n\
-                                default setting: 5\n\n\
+                                default setting: 1\n\n\
     --help:                     print USAGE\n\n\
     --out:                      denotes the output format, the following output options, between \" \", are implemented:\n\n\
-                                       \"score\" : output is the simialrity score\n\
+                                       \"score\" : output is the similarity score\n\
                                        \"matrix\" : output are similarity matrix and similarity score\n\
                                        \"alignment\" : output are the computed alignments to the console as\n\n\
                                Alignment representation of P as symbols of {AminoAcid, gap symbol or number of amino acids in inter-block}\n\
-                               Alignemnt representation of argmax of B as symbols of {argmax AminoAcid for aligned block column, gap symbol or inter-block length}\n\
+                               Alignment representation of argmax of B as symbols of {argmax AminoAcid for aligned block column, gap symbol or inter-block length}\n\
                                Frequency of amino acid of P in aligned block column of B, if alignment type is a match\n\n\
                                         \"matrix+alignment\": output are similarity matrix, \n\
                                                             similarity score and the computed \n\
@@ -843,14 +843,14 @@ USAGE: ./pp_simScore [OPTIONS] --fasta protein_sequence_file --prfl protein_prof
                                                an element of the list consists of:\n\n\
                                - starting position of the first amino acid of the protein sequence that is included in the alignment frame\n\
                                - block number in which the alignment frame is located\n\
-                               - indice of the first block column that is included in the alignment frame\n\
+                               - index of the first block column that is included in the alignment frame\n\
                                - length of the frame (number of alignment columns)\n\
                                - alignment type: 'm', 's'. 'p' or '-'\n\n\
-                                        \"bp\" : output is a list of translations from the indice of a block \n\
+                                        \"bp\" : output is a list of translations from the index of a block \n\
                                                to the number of the block in the .prfl file\n\
                                         \"consents\" : output is the average of the argmax \n\
                                                      of the block columns for the complete profile\n\
-                                        \"interblock\" : output is a list of all inter-block distnace intervals\n\
+                                        \"interblock\" : output is a list of all inter-block distance intervals\n\
                                 default setting: \"score\" \n";
 }
 


### PR DESCRIPTION
- add man page for pp_simScore
- fix typos in pp_simscore.cc
- the default value for parameter "alignment" (number of optimal alignments that are computed) is [1](https://github.com/Gaius-Augustus/Augustus/blob/master/src/pp_simscore.cc#L868), but the usage info tell [5](https://github.com/Gaius-Augustus/Augustus/blob/master/src/pp_simscore.cc#L829)  - I corrected the usage info.