### PR TITLE
Addresses fixed sized buffers that cause file read truncation

### DIFF
--- a/src/extrinsicinfo.cc
+++ b/src/extrinsicinfo.cc
@@ -2120,21 +2120,20 @@ void FeatureCollection::readTypeInfo(istream& datei){
  
 
 void FeatureCollection::readSourceRelatedCFG(istream& datei){
-    char buf[256];
     int sourcenum;
-    string skey;
+    string line, skey;
     datei >> goto_line_after("[SOURCES]") >> comment;
-    datei.getline( buf, 2048 );
+    getline(datei, line);
     // numSources is the number of non-white space characters first
     numSources=0;
     int i=0;
-    while (i< (int) strlen(buf)){
-	while(!isalpha(buf[i]) && i < (int) strlen(buf)){
+    while (i< (int) line.size()){
+	while(!isalpha(line[i]) && i < (int) line.size()){
 	    i++;
 	}
-	if (i < (int) strlen(buf)){
+	if (i < (int) line.size()){
 	    numSources++;
-	    while(isalpha(buf[i])){
+	    while(isalpha(line[i])){
 		i++;
 	    }
 	}
@@ -2149,14 +2148,14 @@ void FeatureCollection::readSourceRelatedCFG(istream& datei){
     numSources=0;
     // construct sourceKey array
     i=0;
-    while (i< (int) strlen(buf)){
-	while(!isalpha(buf[i]) && i < (int) strlen(buf)){
+    while (i< (int) line.size()){
+	while(!isalpha(line[i]) && i < (int) line.size()){
 	    i++;
 	}
-	if (i < (int) strlen(buf)){
+	if (i < (int) line.size()){
 	    sourceKey[numSources] = "";
-	    while(isalpha(buf[i])){
-		sourceKey[numSources] += buf[i]; 
+	    while(isalpha(line[i])){
+		sourceKey[numSources] += line[i]; 
 		i++;
 	    }
 	    numSources++;
@@ -2181,8 +2180,8 @@ void FeatureCollection::readSourceRelatedCFG(istream& datei){
 	bool done = false;
 	while (!done){
 	    bufpos = datei.tellg();
-	    datei.getline(buf, 255);
-	    stringstream stm(buf);
+	    getline(datei, line);
+	    stringstream stm(line);
 	    stm >> skey;
 	    if (stm) {
 		if (!skeyExists(skey)) {

--- a/src/hints.cc
+++ b/src/hints.cc
@@ -73,11 +73,11 @@ ostream& operator<<(ostream&out, Feature& feature){
 }
 
 istream& operator>>( istream& in, Feature& feature ){
-    char buff[1024], copybuff[1024];
+    char buff[8192], copybuff[8192];
     char *temp;
     const char *spos;
     try {
-	in.getline(buff, 1024);
+	in.getline(buff, sizeof(buff));
 	strcpy(copybuff, buff);
 
 	if (strstr(buff, "\t")==NULL) {

--- a/src/phylotree.cc
+++ b/src/phylotree.cc
@@ -107,9 +107,9 @@ PhyloTree::PhyloTree(string filename){
 	    ifstream ifstrm(only_species.c_str());
 	    if (ifstrm.is_open()){
 		vector<string> keep; // the subset of species to be kept
-		char buf[8192];
-		while(ifstrm.getline(buf, sizeof(buf)-1)){
-		    stringstream stm(buf);
+		string line;
+		while(getline(ifstrm, line)){
+		    stringstream stm(line);
 		    string s;
 		    if(stm >> s)
 			keep.push_back(s);

--- a/src/randseqaccess.cc
+++ b/src/randseqaccess.cc
@@ -51,7 +51,7 @@ void SpeciesCollection::addSpeciesToGroup(string skey, int groupID){
 
 void SpeciesCollection::readExtrinsicCFGFile(vector<string> &speciesNames){
     string filename,skey;
-    char buf[1024];
+    string line;
     ifstream datei;
 
     try {
@@ -77,8 +77,8 @@ void SpeciesCollection::readExtrinsicCFGFile(vector<string> &speciesNames){
 		getline(datei,skey);
 		if (skey.find("[GROUP]") != std::string::npos) {
 		    cout << "extrinsic group " << groupCount << ":";	    
-		    datei.getline(buf, 1024); // reading in the set of species that belongs to the group
-		    stringstream stm(buf);
+		    getline(datei, line); // reading in the set of species that belongs to the group
+		    stringstream stm(line);
 		    if(stm >> skey){ 
 			do{
 			    if(skey == "none" || skey == "None"){
@@ -358,16 +358,16 @@ map<string,string> getFileNames (string listfile){
     map<string,string> filenames;
     ifstream ifstrm(listfile.c_str());
     if (ifstrm.is_open()){
-	char buf[256];
-	while(ifstrm.getline(buf,255)){
-	    stringstream stm(buf);
+	string line;
+        while(getline(ifstrm, line)){
+	    stringstream stm(line);
 	    string species, dir;
 	    if(stm >> species >> dir){
 		dir = expandHome(dir);
 		filenames[species] = dir;
 	    }
 	    else
-		throw ProjectError(listfile + " has wrong format in line " + buf + ". correct format:\n\n" + 
+		throw ProjectError(listfile + " has wrong format in line " + line + ". correct format:\n\n" + 
 				   "Homo sapiens <TAB> /dir/to/genome/human.fa\n" + 
 				   "Mus musculus <TAB> /dir/to/genome/mouse.fa\n" + 
 				   "...\n");


### PR DESCRIPTION
This addresses several more cases of line truncation causing read errors.  Mostly by converting to read directly into strings.