### PR TITLE
bam2hints: single pass optimization to support reading from stdin

### DIFF
--- a/auxprogs/bam2hints/bam2hints.cc
+++ b/auxprogs/bam2hints/bam2hints.cc
@@ -499,12 +499,14 @@ int main(int argc, char* argv[])
   {
     cout << "bam2hints -- Convert mRNA-to-genome alignments in BAM format into a hint file for AUGUSTUS in gff format.\n"
 	 << "\n"
-	 << "Usage:   bam2hints --in=example.bam --out=hints.gff\n"
+	 << "Usage:   bam2hints [--in=example.bam] [--out=hints.gff]\n"
 	 << "  PREREQUISITE: input BAM file must be sorted by target (=genome) sequence names\n"
          << "                and within the sequences by begin coordinates\n"
       // TODO: add example of sorting on command line
          << "\n"
          << "  Options:\n"
+         << "  --in=s             -i   input BAM file (default: stdin)\n"
+         << "  --out=s            -o   output GFF hints file (default: stdout)\n"
          << "  --priority=n       -p   priority of hint group (set to " << Pri << ")\n"
          << "  --maxgaplen=n      -g   gaps at most this length are simply closed (set to " << MaxGapLen << ")\n"
          << "  --minintronlen=n   -m   alignments with gaps shorter than this and longer than maxgaplen are discarded (set to " << MinIntLen << ")\n"
@@ -552,9 +554,9 @@ int main(int argc, char* argv[])
   // open the input BAM file
   BamReader BAM;
 
-  if( InFileName == NULL || !BAM.Open(InFileName) )
+  if( !BAM.Open(InFileName == NULL ? "/dev/stdin" : InFileName) )
 	{
-	  cerr << "Could not open input BAM file: " << (InFileName ? InFileName : "No input file") << endl;
+	  cerr << "Could not open input BAM file: " << (InFileName ? InFileName : "/dev/stdin") << endl;
 	  return -1;
 	}
 
@@ -568,11 +570,11 @@ int main(int argc, char* argv[])
 
 
   // open the output gff file
-  FILE* GFF = fopen(OutFileName, "w");
+  FILE* GFF = fopen(OutFileName == NULL ? "/dev/stdout" : OutFileName, "w");
 
   if( GFF == NULL )
   {
-    cerr << "Could not open output file: " << (OutFileName ? OutFileName : "No output file") << endl;
+    cerr << "Could not open output file: " << (OutFileName ? OutFileName : "/dev/stdout") << endl;
     return -1;
   }
 


### PR DESCRIPTION
This PR suggests two optimizations:

1. Read and process the input BAM file in a single pass (instead of the current two). To accomplish this, impacted data structures are converted to vectors that are resized dynamically. In addition to saving some time uncompressing/reading the entire BAM file an extra time, this facilitates # 2:
2. Allow bam2hints to read from stdin. Usually BAM files are sorted by coordinate, whereas bam2hints requires name-sorted BAM. Without support for reading BAM files from stdin, the input BAM must be sorted and written to disk, then read in from disk by bam2hints. By reading from stdin, the output of, e.g., `samtools sort -n` can be piped to bam2hints, avoiding the extra disk I/O & utilization.
3. To express # 2 more naturally, make `--in` and `--out` options really optional, reading from stdin if `--in` is omitted, and writing to stdout of `--out` is omitted. This allows bam2hints to be more naturally plugged into pipelines such as `samtools sort -n my.bam | bam2hints | sort -k 1,1 -k 4n,4n > output.gff'. (if this change is deemed unacceptable for some reason, then it would be good to at least document support for `--in=/dev/stdin` and `--out=/dev/stdout`)
