### PR TITLE
fix typos in species names

### DIFF
--- a/config/species/aedes/aedes_parameters.cfg
+++ b/config/species/aedes/aedes_parameters.cfg
@@ -1,5 +1,5 @@
 #
-# Parameters for Aedes aegypti (yellow fewer mosquito)
+# Parameters for Aedes aegypti (yellow fever mosquito)
 # 
 # date : 13.06.2005
 #

--- a/config/species/fusarium/fusarium_parameters.cfg
+++ b/config/species/fusarium/fusarium_parameters.cfg
@@ -1,5 +1,5 @@
 #
-# Parameters for Fusarium graminearium (fungus)
+# Parameters for Fusarium graminearum (fungus)
 # 
 # date : 15-AUG-2005
 #

--- a/config/species/sealamprey/sealamprey_parameters.cfg
+++ b/config/species/sealamprey/sealamprey_parameters.cfg
@@ -79,7 +79,7 @@ UTR                         off   # predict untranslated regions
 /IGenicModel/patpseudocount 5.0
 /IGenicModel/k              4        # order of the Markov chain for content model, keep equal to /ExonModel/k
 
-# Properties für ExonModel
+# Properties for ExonModel
 # ----------------------------
 /ExonModel/verbosity          3
 /ExonModel/infile             sealamprey_exon_probs.pbl

--- a/docs/HISTORY.TXT
+++ b/docs/HISTORY.TXT
@@ -8,10 +8,10 @@ List of changes from version 3.3.3 to 3.4.0 (until Dec 11th, 2020)
      - new default: softmasking is assumed
      - compile with CGP and ZIPINPUT support by default
      - compile with SQLite and MySQL support for CGP (switch of by adding SQLite = false and MySQL = false to common.mk)
-     - new species Cassiopea xamachana, Ptychodera flava, Argopecten irridians, Nemopilema nomurai
+     - new species Cassiopea xamachana, Ptychodera flava, Argopecten irradians, Nemopilema nomurai
        Notospermus_geniculatus, Chrysaora chesapeakei, Ectocarpus siliculosus, Trichoplax adhaerens,
        Aurelia aurita, Rhopilema esculentum, Encephalitozoon cuniculi, Gonapodya prolifera, Dunaliella_salina
-       Sordaria macrospora, Sphaceloma murrayae, Vitrella brassicaformis, Monoraphidium neglectum, Raphidocelis subcapita,
+       Sordaria macrospora, Sphaceloma murrayae, Vitrella brassicaformis, Monoraphidium neglectum, Raphidocelis subcapitata,
        Ostreococcus tauri, Ostreococcus sp. lucimarinus, Micromonas pusilla, Micromonas_commoda, Chlamydomonas eustigma,
        Thalassiosira pseudonana, Pseudo-nitzschia multistriata, Phaeodactylum tricornutum, Fragilariopsis cylindrus,\
        Fistulifera solaris, Bathycoccus prasinos, Chloropicon primus
@@ -282,7 +282,7 @@ List of changes from version 1.8 to version 1.8.2 (until March 10th, 2006):
      - Species parameters contributed by Jason Stajich: Caenorhabditis
        elegans, Saccharomyces cerevisiae, Ustilago maydis, Phanerochaete
        chrysosporium, Neurospora crassa, Histoplasma capsulatum, Fusarium
-       graminearium, Cryptococcus neoformans, Aspergillus nidulans
+       graminearum, Cryptococcus neoformans, Aspergillus nidulans
 
 List of changes from version 1.7 to version 1.8 (until January 18th, 2006):
 

--- a/docs/RUNNING-AUGUSTUS.md
+++ b/docs/RUNNING-AUGUSTUS.md
@@ -70,7 +70,7 @@ debaryomyces_hansenii                    | Debaryomyces hansenii
 encephalitozoon_cuniculi_GB              | Encephalitozoon cuniculi
 eremothecium_gossypii                    | Eremothecium gossypii
 fusarium_graminearum                     | Fusarium graminearum
-(fusarium)                               | Fusarium graminearium
+(fusarium)                               | Fusarium graminearum
 histoplasma_capsulatum                   | Histoplasma capsulatum
 (histoplasma)                            | Histoplasma capsulatum
 kluyveromyces_lactis                     | Kluyveromyces lactis

--- a/docs/tutorial2018/README_augustus.TXT
+++ b/docs/tutorial2018/README_augustus.TXT
@@ -269,7 +269,7 @@ debaryomyces_hansenii                    | Debaryomyces hansenii
 encephalitozoon_cuniculi_GB              | Encephalitozoon cuniculi
 eremothecium_gossypii                    | Eremothecium gossypii
 fusarium_graminearum                     | Fusarium graminearum
-(fusarium)                               | Fusarium graminearium
+(fusarium)                               | Fusarium graminearum
 histoplasma_capsulatum                   | Histoplasma capsulatum
 (histoplasma)                            | Histoplasma capsulatum
 kluyveromyces_lactis                     | Kluyveromyces lactis

--- a/include/types.hh
+++ b/include/types.hh
@@ -141,8 +141,8 @@ fly                                      | Drosophila melanogaster\n\
 encephalitozoon_cuniculi_GB              | Encephalitozoon cuniculi\n\
 eremothecium_gossypii                    | Eremothecium gossypii\n\
 E_coli_K12                               | Escherichia coli K12\n\
-fusarium_graminearum                     | Fusarium graminearium\n\
-(fusarium)                               | Fusarium graminearium\n\
+fusarium_graminearum                     | Fusarium graminearum\n\
+(fusarium)                               | Fusarium graminearum\n\
 galdieria                                | Galdieria sulphuraria\n\
 chicken                                  | Gallus gallus domesticus\n\
 heliconius_melpomene1                    | Heliconius melpomene\n\
@@ -197,7 +197,7 @@ ustilago_maydis                          | Ustilago maydis\n\
 verticillium_albo_atrum1                 | Verticillium albo atrum\n\
 verticillium_longisporum1                | Verticillium longisporum\n\
 volvox                                   | Volvox sp.\n\
-Xipophorus_maculatus                     | Xipophorus maculatus\n\
+Xiphophorus_maculatus                    | Xiphophorus maculatus\n\
 yarrowia_lipolytica                      | Yarrowia lipolytica\n\
 maize                                    | Zea mays\n\
 (maize5)                                 | Zea mays\n\


### PR DESCRIPTION
see also the note #285 by @OnlineArts

this species folder names have not yet been renamed:
(the current names are still synonyms of the species)

candida_guilliermondii	
 - current binomial name: Meyerozyma guilliermondii
 - current synonym: "Candida guilliermondii (Castell.) Langeron & Guerra, 1938"

pichia_stipitis
 - current binomial name: "Scheffersomyces stipitis"
 - current synonym: "Pichia stipitis"

phanerochaete_chrysosporium
 - current binomial name: "Phanerodontia chrysosporium"
 - current synonym: "Phanerochaete chrysosporium"
 - there exists a strain "Phanerochaete chrysosporium RP-78" 

