### PR TITLE
fix errormessages gff2gbSmallDna.pl mentioned in #324

### DIFF
--- a/scripts/gff2gbSmallDNA.pl
+++ b/scripts/gff2gbSmallDNA.pl
@@ -587,17 +587,15 @@ sub printseq {
     print OUTPUT "\nORIGIN\n";
     $i = 1;
     $pos = 0;
-    while ($pos <= length $seq) {
+    while ($pos < length $seq) {
         $zahlzeile = "";
         for ($j=0; $j < 9-length "$i"; $j=$j+1) {
             print OUTPUT " ";
         }
         print OUTPUT "$i";
-        for ($j=0; $j < 6; $j=$j+1) {
+        for ($j=0; $j < 6 && $pos < length $seq; $j=$j+1) {
              $ten = substr $seq, $pos, 10;
-             if (length $ten > 0) {
-                 print OUTPUT " $ten";
-             }
+             print OUTPUT " $ten";
              $pos = $pos + 10; #$seq = substr $seq, 10;
         }
         print OUTPUT "\n";

--- a/scripts/gff2gbSmallDNA.pl
+++ b/scripts/gff2gbSmallDNA.pl
@@ -382,6 +382,7 @@ while(<FASTA>) {
 		    $shiftedfeatures[$j] -= $offset if (!$connected);
 		}
 		$newseq = substr($seq, $currentSeqBegin - 1, $currentSeqEnd - $currentSeqBegin + 1 );
+		$newlength = length $newseq;
 		&printdata(@shiftedfeatures);
 		&printseq($newseq, $newlength) if (!$connected);
 	    }


### PR DESCRIPTION
fix bugs leading to this error messages (see #324):
- Use of uninitialized value $length in subtraction (-) at gff2gbSmallDNA.pl line 578
- substr outside of string at gff2gbSmallDNA.pl line 596
- Use of uninitialized value $ten in numeric gt (>) at gff2gbSmallDNA.pl line 597

The output remains unchanged except in the rare cases where the genome fasta file contains letters other than atcgn in the sequence.
