### PR TITLE
fixes #346

### DIFF
--- a/src/pp_profile.cc
+++ b/src/pp_profile.cc
@@ -672,7 +672,7 @@ void Profile::parse_stream(istream & strm) {
             // read in the allowed distance range
             istringstream lstrm(readAndConcatPart(strm, type, lineno));
             DistanceType addDist;
-            if(!(lstrm >> addDist && lstrm.eof()))
+            if(!(lstrm >> addDist && lstrm.peek() == EOF))
                 throw ProfileParseError(lineno - newlinesFromPos(lstrm.str(), lstrm.tellg()) -1);
             finalDist += addDist;
             } else // if dist is not specified, assume arbitrary distance

--- a/src/pp_profile.cc
+++ b/src/pp_profile.cc
@@ -672,7 +672,7 @@ void Profile::parse_stream(istream & strm) {
             // read in the allowed distance range
             istringstream lstrm(readAndConcatPart(strm, type, lineno));
             DistanceType addDist;
-            if(!(lstrm >> addDist >> ws && lstrm.eof()))
+            if(!(lstrm >> addDist && lstrm.eof()))
                 throw ProfileParseError(lineno - newlinesFromPos(lstrm.str(), lstrm.tellg()) -1);
             finalDist += addDist;
             } else // if dist is not specified, assume arbitrary distance


### PR DESCRIPTION
- an incorrect `ProfileParseError` is raised for Augustus-ppx if a new version of `libstdc++` is used
- this problem is caused by `std::ws` because it sets `lstrm.fail()` to true if `lstrm.eof()` is already true (in the new version of `libstdc++`)
- `std::ws` wasn't necessary for catching a `ProfileParseError` in the first place, removing it here resolves the issue