### PR TITLE
fixed issue #370 with segmentation fault during CRF training

### DIFF
--- a/include/gene.hh
+++ b/include/gene.hh
@@ -602,6 +602,15 @@ public:
 bool isAllLC(AnnoSequence *seqs);
 
 
+/*
+ * Print a warning if --softmasking=1 (default) and all sequences are
+ * completely in lowercase characters. This can happen in particular
+ * if the input is from GenBank.
+ */
+void warnAllLowerCase(AnnoSequence *annoseq);
+
+
+
 /**
  * 
  * @author Mario Stanke

--- a/src/augustus.cc
+++ b/src/augustus.cc
@@ -89,14 +89,6 @@ void cutRelevantPiece(AnnoSequence *annoseq);
 
 
 /*
- * Print a warning if --softmasking=1 (default) and all sequences are
- * completely in lowercase characters. This can happen in particular
- * if the input is from GenBank.
- */
-void warnAllLowerCase(AnnoSequence *annoseq);
-
-
-/*
  * main
  */
 int main( int argc, char* argv[] ){
@@ -604,21 +596,3 @@ void cutRelevantPiece(AnnoSequence *annoseq){
         annoseq->offset = -predictionStart - 1;
     }
 }
-
-
-
-/*
- * Print a warning if --softmasking=1 (default) and all sequences are
- * completely in lowercase characters. This can happen in particular
- * if the input is from GenBank.
- */
-void warnAllLowerCase(AnnoSequence *annoseq){
-    if (Constant::softmasking && isAllLC(annoseq)){
-        cerr << "#########################################################################" << endl
-             << "# WARNING: --softmasking=1 and all sequences are completely in lower case." << endl
-             << "# They will be treated as repeatmasked everywhere and genes could be severely underpredicted." << endl
-             << "# If this is not intended, rerun with --softmasking=0" << endl
-             << "#########################################################################" << endl;
-    }
-}
-

--- a/src/etraining.cc
+++ b/src/etraining.cc
@@ -93,6 +93,10 @@ int main( int argc, char* argv[] ){
 	  verbosity = Properties::getIntProperty("/augustus/verbosity");
 	} catch (...) {}
 	trainannoseq = traingbank.getAnnoSequenceList();
+	if (!Constant::softmasking_explicitly_requested){
+            Constant::softmasking = false; // default is false only for .gb files
+	}
+	warnAllLowerCase(trainannoseq);
 	singletrainannoseq = EHMMTraining::split2SingleGeneSeqs(trainannoseq);
 
 	if (!singletrainannoseq){
@@ -104,7 +108,9 @@ int main( int argc, char* argv[] ){
 	
 	// TODO: read in the hints for training
 	FeatureCollection extrinsicFeatures;
-	
+	if (Constant::softmasking) {
+	    extrinsicFeatures.readExtrinsicCFGFile();
+	}
 
 	BaseCount *bc = new BaseCount();
 	ContentDecomposition cd;

--- a/src/extrinsicinfo.cc
+++ b/src/extrinsicinfo.cc
@@ -1883,7 +1883,7 @@ void SequenceFeatureCollection::prepareLocalMalus(const char* dna){
  * localSSMalus
  */
 double SequenceFeatureCollection::localSSMalus(FeatureType type, int pos, Strand strand){
-  if (pos < 0 || pos >= seqlen ||
+  if (hasLocalSSmalus == NULL || pos < 0 || pos >= seqlen ||
       (type == dssF && strand == plusstrand && !hasLocalSSmalus[pos][forwDSS]) ||
       (type == dssF && strand == minusstrand && !hasLocalSSmalus[pos][revDSS]) ||
       (type == assF && strand == plusstrand && !hasLocalSSmalus[pos][forwASS]) ||

--- a/src/gene.cc
+++ b/src/gene.cc
@@ -2977,6 +2977,22 @@ bool isAllLC(AnnoSequence *annoseq) {
 
 
 
+/*
+ * Print a warning if --softmasking=1 (default) and all sequences are
+ * completely in lowercase characters. This can happen in particular
+ * if the input is from GenBank.
+ */
+void warnAllLowerCase(AnnoSequence *annoseq){
+    if (Constant::softmasking && isAllLC(annoseq)){
+        cerr << "#########################################################################" << endl
+             << "# WARNING: --softmasking=1 and all sequences are completely in lower case." << endl
+             << "# They will be treated as repeatmasked everywhere and genes could be severely underpredicted." << endl
+             << "# If this is not intended, rerun with --softmasking=0" << endl
+             << "#########################################################################" << endl;
+    }
+}
+
+
 /* --- StatePathCollection methods --------------------------------- */
 
 /*


### PR DESCRIPTION
The assumption of no softmasking is now the default for training on input Genbank files, unless explicitly turned on with --softmasking=1.