### PR TITLE
Fix for individual liability setting for extrinsic evidence 

### DIFF
--- a/include/extrinsicinfo.hh
+++ b/include/extrinsicinfo.hh
@@ -392,6 +392,8 @@ public:
     bool skeyExists(string skey);
     int esource(string skey);
     bool getIndividualLiability(string skey){return individual_liability[esource(skey)];}
+    bool getIndividualLiabilitySetting(string skey){return individual_liability_setting[esource(skey)];}
+    void setGroupLiable(string skey){individual_liability[esource(skey)] = false;}
     bool get1group1gene(string skey){return oneGroupOneGene[esource(skey)];}
     double malus(FeatureType type){
 	return typeInfo[type].malus;
@@ -410,7 +412,8 @@ private:
 
     int numSources;              // number of different sources of hints
     string *sourceKey;           // for each source the key string
-    bool *individual_liability;  // for each source the flag individual_liability
+    bool *individual_liability_setting;  // for each source the flag individual_liability_setting
+    bool *individual_liability;
     bool *oneGroupOneGene;       // for each source the flag 1group1gene
     FeatureTypeInfo typeInfo[NUM_FEATURE_TYPES]; // the type-specific information
     map<string, SequenceFeatureCollection*> collections;

--- a/src/extrinsicinfo.cc
+++ b/src/extrinsicinfo.cc
@@ -538,7 +538,7 @@ void SequenceFeatureCollection::checkGroupConsistency(AnnoSequence *seq){
 	    /*
 	     * Now make changes to strand or discard group.
 	     */
-	    if (!plusPossible && !minusPossible) { // no strand possible
+		if (!plusPossible && !minusPossible) { // no strand possible
 		if (!plusPossible || !minusPossible) { // only one stand possible, set that strand for all hints
 		for (fit = hints->begin(); fit != hints->end(); fit++) {
 		    if (!minusPossible && (*fit)->strand != plusstrand){
@@ -563,8 +563,9 @@ void SequenceFeatureCollection::checkGroupConsistency(AnnoSequence *seq){
 	    if (!groupOK){
 		git->setDiscardFlag(true);
 		numDeleted++;
-		if (!collection->getIndividualLiabilitySetting((*hints->begin())->esource))
+		if (!collection->getIndividualLiabilitySetting((*hints->begin())->esource)) {
 			collection->setGroupLiable((*hints->begin())->esource); 
+		}
 		if (Constant::augustus_verbosity>2) {
 		    messages << "# Delete group ";
 		    git->print(messages, false);
@@ -2168,7 +2169,7 @@ void FeatureCollection::readSourceRelatedCFG(istream& datei){
     }
     sourceKey = new string[numSources];
     individual_liability_setting = new bool[numSources];
-	individual_liability = new bool[numSources];
+    individual_liability = new bool[numSources];
     oneGroupOneGene = new bool[numSources];
     for (int i=0; i<numSources; i++) {
 	individual_liability_setting[i] = false;

--- a/src/extrinsicinfo.cc
+++ b/src/extrinsicinfo.cc
@@ -539,9 +539,7 @@ void SequenceFeatureCollection::checkGroupConsistency(AnnoSequence *seq){
 	     * Now make changes to strand or discard group.
 	     */
 	    if (!plusPossible && !minusPossible) { // no strand possible
-		if (!collection->getIndividualLiability((*(hints->begin()))->esource))
-		    groupOK = false; // let the whole group suffer if one hints is unsatisfyable
-	    } else if (!plusPossible || !minusPossible) { // only one stand possible, set that strand for all hints
+		if (!plusPossible || !minusPossible) { // only one stand possible, set that strand for all hints
 		for (fit = hints->begin(); fit != hints->end(); fit++) {
 		    if (!minusPossible && (*fit)->strand != plusstrand){
 			(*fit)->strand = plusstrand;
@@ -579,6 +577,21 @@ void SequenceFeatureCollection::checkGroupConsistency(AnnoSequence *seq){
 	    git++;
 	}
     }
+	}
+	for (git = groupList->begin(); git != groupList->end(); ) {
+	if (!collection->getIndividualLiability((*(git->getHints()->begin()))->esource)) {
+		// let the whole group suffer if one hints is unsatisfyable
+		git->setDiscardFlag(true);
+		numDeleted++;
+		if (Constant::augustus_verbosity>2) {
+		    messages << "# Delete group because of unreliable source: ";
+		    git->print(messages, false);
+		}
+		git=groupList->erase(git);
+	} else {
+		git++;
+	}
+	} 
     if (numForcedStrand > 0)
 	messages << "# Forced unstranded hint group to the only possible strand for " << numForcedStrand << " groups." << endl;
     if (numDeleted)

--- a/src/extrinsicinfo.cc
+++ b/src/extrinsicinfo.cc
@@ -564,7 +564,9 @@ void SequenceFeatureCollection::checkGroupConsistency(AnnoSequence *seq){
 	    }
 	    if (!groupOK){
 		git->setDiscardFlag(true);
-		numDeleted++; 
+		numDeleted++;
+		if (!collection->getIndividualLiabilitySetting((*hints->begin())->esource))
+			collection->setGroupLiable((*hints->begin())->esource); 
 		if (Constant::augustus_verbosity>2) {
 		    messages << "# Delete group ";
 		    git->print(messages, false);
@@ -2003,11 +2005,11 @@ FeatureCollection::FeatureCollection(const FeatureCollection& other){
     numSeqsWithInfo=other.numSeqsWithInfo;
     numSources=other.numSources;
     sourceKey = new string[numSources];
-    individual_liability = new bool[numSources];
+    individual_liability_setting = new bool[numSources];
     oneGroupOneGene = new bool[numSources];
     for (int i=0; i<numSources; i++) {
 	sourceKey[i] = other.sourceKey[i];
-	individual_liability[i] = other.individual_liability[i];
+	individual_liability_setting[i] = other.individual_liability_setting[i];
 	oneGroupOneGene[i] = other.oneGroupOneGene[i];
     }
     for(int i=0; i < NUM_FEATURE_TYPES; i++){
@@ -2152,10 +2154,12 @@ void FeatureCollection::readSourceRelatedCFG(istream& datei){
 	}
     }
     sourceKey = new string[numSources];
-    individual_liability = new bool[numSources];
+    individual_liability_setting = new bool[numSources];
+	individual_liability = new bool[numSources];
     oneGroupOneGene = new bool[numSources];
     for (int i=0; i<numSources; i++) {
-	individual_liability[i] = false;
+	individual_liability_setting[i] = false;
+	individual_liability[i] = true;
 	oneGroupOneGene[i] = false;
     }
     numSources=0;
@@ -2207,7 +2211,7 @@ void FeatureCollection::readSourceRelatedCFG(istream& datei){
 			if (eqpos == string::npos){ // single string option
 			    if (option == "individual_liability"){ // an unsatisfyable hint doesn't touch the other hints of the group
 				cout << "# Setting " << option << " for " << skey << "." << endl;
-				individual_liability[sourcenum] = true;
+				individual_liability_setting[sourcenum] = true;
 			    } else if (option == "1group1gene"){ // try not to predict igenic region in intra-group gaps
 				cout << "# Setting " << option << " for " << skey << "." << endl;
 				oneGroupOneGene[sourcenum] = true;


### PR DESCRIPTION
Hi,

I've found that the individual liability setting for hints does not seem to work as intended. As long as it was not set, all hints of the source where discarded, rendering all hints without this setting useless. This can also be seen in many of the examples (such as in docs/tutorial/results/augustus.hints.gff), where hints are deleted without giving any reason for the deletion.

I think what I've written here should fix the issue and I've tested it on my own data. Basically as soon as a hint is found that is not ok and the individual liability setting is not set for it's source, the sources liability is set to false. Then, after all hints have been processed, all hints belonging to a source that had an unreliable hint are deleted.

From what I can tell, this should have quite a large performance impact especially on BRAKER, as so far many hints might have incorrectly been ignored.

Please let me know if this doesn't produce the desired behavior, I'm also happy to adjust some things if necessary.

Cheers!