### PR TITLE
fix: gcc13 failed with this

### DIFF
--- a/auxprogs/homGeneMapping/include/sqliteDB.hh
+++ b/auxprogs/homGeneMapping/include/sqliteDB.hh
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <sqlite3.h>
+#include <cstdint>
 
 using namespace std;
 

--- a/include/sqliteDB.hh
+++ b/include/sqliteDB.hh
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <sqlite3.h>
+#include <cstdint>
 
 using namespace std;
 


### PR DESCRIPTION
report log is here

- gcc: 13.1.1 20230429
- OS: archlinux

```
In file included from sqliteDB.cc:10:
../include/sqliteDB.hh:93:29: error: ‘uint64_t’ has not been declared
   93 |     void bindInt64(int idx, uint64_t x);
      |                             ^~~~~~~~
../include/sqliteDB.hh:102:12: error: ‘uint64_t’ does not name a type
  102 |     inline uint64_t int64Column(int colNum){return (uint64_t)sqlite3_column_int64(stmt,colNum);}
      |            ^~~~~~~~
../include/sqliteDB.hh:14:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   13 | #include <sqlite3.h>
  +++ |+#include <cstdint>
   14 | 
g++ -DZIPINPUT -DCOMPGENEPRED -DTESTING -DM_MYSQL -DM_SQLITE -Wall -Wno-sign-compare -pedantic -O3 -std=c++11 -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -flto=auto -I../include -I/usr/include/lpsolve    -I/usr/include/mysql     -c -o commontrain.o commontrain.cc
sqliteDB.cc:210:6: error: no declaration matches ‘void Statement::bindInt64(int, uint64_t)’
  210 | void Statement::bindInt64(int idx, uint64_t x){
      |      ^~~~~~~~~
../include/sqliteDB.hh:93:10: note: candidate is: ‘void Statement::bindInt64(int, int)’
   93 |     void bindInt64(int idx, uint64_t x);
      |          ^~~~~~~~~
../include/sqliteDB.hh:83:7: note: ‘class Statement’ defined here
   83 | class Statement
      |       ^~~~~~~~~
make[1]: *** [Makefile:85: sqliteDB.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/build/augustus/src/Augustus-3.5.0/src'
make: *** [Makefile:12: augustus] Error 2
```