### PR TITLE
filterBam: include missing header for gcc15

### DIFF
--- a/auxprogs/filterBam/src/headers/bamaccess.hh
+++ b/auxprogs/filterBam/src/headers/bamaccess.hh
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 class BamAlignmentRecord;
 typedef std::shared_ptr<BamAlignmentRecord> BamAlignmentRecord_;


### PR DESCRIPTION
```
x86_64-pc-linux-gnu-g++  -Wall -Wextra -Wpedantic -std=c++11 -O3 -O2 -pipe -march=native -fno-diagnostics-color -I./headers -I/usr/include/bamtools  -c filterBam.cc
In file included from ./headers/filterBam.h:10,
                 from filterBam.cc:28:
./headers/bamaccess.hh:76:13: error: ‘uint32_t’ does not name a type
   76 |     virtual uint32_t countEqualSignsInQuerySequence() const = 0;
      |             ^~~~~~~~
./headers/bamaccess.hh:10:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    9 | #include <memory>
  +++ |+#include <cstdint>
   10 | 
./headers/bamaccess.hh:84:13: error: ‘uint32_t’ does not name a type
   84 |     virtual uint32_t countCigarOperations(const char& type) const = 0;
      |             ^~~~~~~~
```

https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes

Bug: https://bugs.gentoo.org/949617