### PR TITLE
Removed code chunk that adds '_odb10' to the end of any specified BUSCO lineage

### DIFF
--- a/scripts/compleasm_to_hints.py
+++ b/scripts/compleasm_to_hints.py
@@ -123,10 +123,6 @@ def main():
         if not os.access(args.compleasm, os.X_OK):
             raise FileNotFoundError("compleasm is not executable")
         
-    # check whether the database has the ending odb_10, if not, add it
-    if not args.database.endswith("_odb10"):
-        args.database = args.database + "_odb10"
-
     # apply compleasm to genome file with run_subprocess and the database
     if args.scratch_dir is None:
         args.scratch_dir = "compleasm_genome_out"


### PR DESCRIPTION
These updates make compleasm_to_hints.py compatible with compleasm.py v0.2.8 (present in BRAKER3 docker container v3.1.1) which is only compatible with odb12 BUSCO lineages.